### PR TITLE
Add SQLite as database backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,6 +2550,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2625,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
@@ -3066,6 +3078,7 @@ dependencies = [
  "once_cell",
  "psp-compressed-pda",
  "psp-compressed-token",
+ "rstest",
  "sea-orm",
  "serde",
  "serde_json",
@@ -4592,6 +4605,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "relative-path"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4711,6 +4730,35 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version 0.4.0",
+ "syn 2.0.51",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,6 +2392,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "pin-project",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,6 +3349,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
 dependencies = [
  "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -6153,6 +6176,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -6411,8 +6437,10 @@ dependencies = [
  "dotenvy",
  "either",
  "event-listener 2.5.3",
+ "flume",
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-intrusive",
  "futures-util",
  "hashlink",
@@ -6422,6 +6450,7 @@ dependencies = [
  "indexmap 1.9.3",
  "itoa",
  "libc",
+ "libsqlite3-sys",
  "log",
  "md-5",
  "memchr",
@@ -7182,6 +7211,12 @@ name = "value-bag"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126e423afe2dd9ac52142e7e9d5ce4135d7e13776c529d27fd6bc49f19e3280b"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ sea-orm = {version = "0.10.6", features = [
   "macros",
   "runtime-tokio-rustls",
   "sqlx-postgres",
+  "sqlx-sqlite",
   "with-chrono",
   "mock",
 ]}
@@ -59,6 +60,7 @@ sqlx = {version = "0.6.2", features = [
   "macros",
   "runtime-tokio-rustls",
   "postgres",
+  "sqlite",
   "uuid",
   "offline",
   "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ open-rpc-derive = {version = "0.0.4"}
 open-rpc-schema = {version = "0.0.4"}
 psp-compressed-pda = {git = "https://github.com/Lightprotocol/light-protocol.git", branch = "emit-indexable-for-photon"}
 psp-compressed-token = {git = "https://github.com/Lightprotocol/light-protocol.git", branch = "emit-indexable-for-photon"}
+rstest = "0.18.2"
 schemars = {version = "0.8.6", features = ["chrono"]}
 schemars_derive = "0.8.6"
 sea-orm = {version = "0.10.6", features = [

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -24,6 +24,7 @@ migration = {workspace = true}
 once_cell = {workspace = true}
 psp-compressed-pda = {workspace = true}
 psp-compressed-token = {workspace = true}
+rstest = {workspace = true}
 sea-orm = {workspace = true}
 serde = {workspace = true}
 serde_json = {workspace = true}

--- a/integration_tests/tests/integration_tests/parsing_tests.rs
+++ b/integration_tests/tests/integration_tests/parsing_tests.rs
@@ -1,43 +1,43 @@
-use api::{api::ApiContract, method::get_utxos::GetUtxosRequest};
-use function_name::named;
-use ingester::{parser::parse_transaction, persist::persist_bundle};
-use serial_test::serial;
+// use api::{api::ApiContract, method::get_utxos::GetUtxosRequest};
+// use function_name::named;
+// use ingester::{parser::parse_transaction, persist::persist_bundle};
+// use serial_test::serial;
 
-use crate::utils::*;
+// use crate::utils::*;
 
-#[tokio::test]
-#[serial]
-#[named]
-async fn test_e2e() {
-    let name = trim_test_name(function_name!());
-    let setup = setup_with_options(
-        name,
-        TestSetupOptions {
-            network: Network::Localnet,
-        },
-    )
-    .await;
+// #[tokio::test]
+// #[serial]
+// #[named]
+// async fn test_e2e() {
+//     let name = trim_test_name(function_name!());
+//     let setup = setup_with_options(
+//         name,
+//         TestSetupOptions {
+//             network: Network::Localnet,
+//         },
+//     )
+//     .await;
 
-    let tx = cached_fetch_transaction(
-        &setup,
-        "2y27eTCZ53DiFubUqBtstcrFrDCvr1sqCJFYDnjFVuZrrCGXvQPfVVosBv7mYF3LeJRy73EiGzqPX2vWHDg4iRCk",
-    )
-    .await;
+//     let tx = cached_fetch_transaction(
+//         &setup,
+//         "2y27eTCZ53DiFubUqBtstcrFrDCvr1sqCJFYDnjFVuZrrCGXvQPfVVosBv7mYF3LeJRy73EiGzqPX2vWHDg4iRCk",
+//     )
+//     .await;
 
-    let events = parse_transaction(tx).unwrap();
-    assert_eq!(events.len(), 1);
-    for event in events {
-        persist_bundle(&setup.db_conn, event).await.unwrap();
-    }
-    let utxos = setup
-        .api
-        .get_utxos(GetUtxosRequest {
-            owner: "8uxi3FheruZNcPfq4WKGQD19xB44QMfUGuFLij9JWeJ"
-                .try_into()
-                .unwrap(),
-        })
-        .await
-        .unwrap();
+//     let events = parse_transaction(tx).unwrap();
+//     assert_eq!(events.len(), 1);
+//     for event in events {
+//         persist_bundle(&setup.db_conn, event).await.unwrap();
+//     }
+//     let utxos = setup
+//         .api
+//         .get_utxos(GetUtxosRequest {
+//             owner: "8uxi3FheruZNcPfq4WKGQD19xB44QMfUGuFLij9JWeJ"
+//                 .try_into()
+//                 .unwrap(),
+//         })
+//         .await
+//         .unwrap();
 
-    assert_eq!(utxos.total, 1);
-}
+//     assert_eq!(utxos.total, 1);
+// }

--- a/integration_tests/tests/integration_tests/parsing_tests.rs
+++ b/integration_tests/tests/integration_tests/parsing_tests.rs
@@ -1,43 +1,47 @@
-// use api::{api::ApiContract, method::get_utxos::GetUtxosRequest};
-// use function_name::named;
-// use ingester::{parser::parse_transaction, persist::persist_bundle};
-// use serial_test::serial;
+use api::{api::ApiContract, method::get_utxos::GetUtxosRequest};
+use function_name::named;
+use ingester::{parser::parse_transaction, persist::persist_bundle};
+use serial_test::serial;
 
-// use crate::utils::*;
+use crate::utils::*;
 
-// #[tokio::test]
-// #[serial]
-// #[named]
-// async fn test_e2e() {
-//     let name = trim_test_name(function_name!());
-//     let setup = setup_with_options(
-//         name,
-//         TestSetupOptions {
-//             network: Network::Localnet,
-//         },
-//     )
-//     .await;
+#[named]
+#[rstest]
+#[tokio::test]
+#[serial]
+async fn test_e2e(
+    #[values(DatabaseBackend::Sqlite, DatabaseBackend::Postgres)] db_backend: DatabaseBackend,
+) {
+    let name = trim_test_name(function_name!());
+    let setup = setup_with_options(
+        name,
+        TestSetupOptions {
+            network: Network::Localnet,
+            db_backend,
+        },
+    )
+    .await;
 
-//     let tx = cached_fetch_transaction(
-//         &setup,
-//         "2y27eTCZ53DiFubUqBtstcrFrDCvr1sqCJFYDnjFVuZrrCGXvQPfVVosBv7mYF3LeJRy73EiGzqPX2vWHDg4iRCk",
-//     )
-//     .await;
+    let tx = cached_fetch_transaction(
+        &setup,
+        "2y27eTCZ53DiFubUqBtstcrFrDCvr1sqCJFYDnjFVuZrrCGXvQPfVVosBv7mYF3LeJRy73EiGzqPX2vWHDg4iRCk",
+    )
+    .await;
 
-//     let events = parse_transaction(tx).unwrap();
-//     assert_eq!(events.len(), 1);
-//     for event in events {
-//         persist_bundle(&setup.db_conn, event).await.unwrap();
-//     }
-//     let utxos = setup
-//         .api
-//         .get_utxos(GetUtxosRequest {
-//             owner: "8uxi3FheruZNcPfq4WKGQD19xB44QMfUGuFLij9JWeJ"
-//                 .try_into()
-//                 .unwrap(),
-//         })
-//         .await
-//         .unwrap();
+    let events = parse_transaction(tx).unwrap();
+    assert_eq!(events.len(), 1);
+    for event in events {
+        persist_bundle(&setup.db_conn, event).await.unwrap();
+    }
+    let utxos = setup
+        .api
+        .get_utxos(GetUtxosRequest {
+            owner: "8uxi3FheruZNcPfq4WKGQD19xB44QMfUGuFLij9JWeJ"
+                .try_into()
+                .unwrap(),
+        })
+        .await
+        .unwrap();
 
-//     assert_eq!(utxos.total, 1);
-// }
+    assert_eq!(utxos.total, 1);
+}

--- a/integration_tests/tests/integration_tests/persist_tests.rs
+++ b/integration_tests/tests/integration_tests/persist_tests.rs
@@ -22,8 +22,6 @@ use psp_compressed_token::TokenTlvData;
 use serial_test::serial;
 use solana_sdk::{pubkey::Pubkey, signature::Signature};
 
-use rstest::rstest;
-
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone)]
 struct Person {
     name: String,
@@ -44,8 +42,6 @@ struct Person {
 async fn test_persist_state_transitions(
     #[values(DatabaseBackend::Sqlite, DatabaseBackend::Postgres)] db_backend: DatabaseBackend,
 ) {
-    let full_name = function_name!();
-    println!("Starting {full_name} {:?}...", db_backend);
     let name = trim_test_name(function_name!());
     let setup = setup(name, db_backend).await;
     let owner = Pubkey::new_unique();
@@ -115,7 +111,6 @@ async fn test_persist_state_transitions(
     let raw_data = base64::decode(res.data).unwrap();
     assert_eq!(person_tlv, Tlv::try_from_slice(&raw_data).unwrap());
     assert_eq!(res.lamports, utxo.lamports as i64);
-    println!("Finished {full_name} {:?}...", db_backend);
 }
 
 #[named]
@@ -125,8 +120,6 @@ async fn test_persist_state_transitions(
 async fn test_persist_token_data(
     #[values(DatabaseBackend::Sqlite, DatabaseBackend::Postgres)] db_backend: DatabaseBackend,
 ) {
-    let full_name = function_name!();
-    println!("Starting {full_name} {:?}...", db_backend);
     let name = trim_test_name(function_name!());
     let setup = setup(name, db_backend).await;
     let mint1 = Pubkey::new_unique();
@@ -235,5 +228,4 @@ async fn test_persist_token_data(
     );
     assert_eq!(res.is_native, false);
     assert_eq!(res.close_authority, None);
-    println!("Finished {full_name} {:?}...", db_backend);
 }

--- a/photon/src/main.rs
+++ b/photon/src/main.rs
@@ -24,15 +24,15 @@ use std::sync::Arc;
 
 #[derive(Parser, Debug, Clone, ValueEnum)]
 enum LoggingFormat {
-    STANDARD,
-    JSON,
+    Standard,
+    Json,
 }
 
 impl fmt::Display for LoggingFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LoggingFormat::STANDARD => write!(f, "standard"),
-            LoggingFormat::JSON => write!(f, "json"),
+            LoggingFormat::Standard => write!(f, "standard"),
+            LoggingFormat::Json => write!(f, "json"),
         }
     }
 }
@@ -64,7 +64,7 @@ struct Args {
     max_db_conn: u32,
 
     /// Logging format
-    #[arg(short, long, default_value_t = LoggingFormat::STANDARD)]
+    #[arg(short, long, default_value_t = LoggingFormat::Standard)]
     logging_format: LoggingFormat,
 }
 
@@ -138,8 +138,8 @@ fn setup_logging(logging_format: LoggingFormat) {
         env::var("RUST_LOG").unwrap_or("info,sqlx=error,sea_orm_migration=error".to_string());
     let subscriber = tracing_subscriber::fmt().with_env_filter(env_filter);
     match logging_format {
-        LoggingFormat::STANDARD => subscriber.init(),
-        LoggingFormat::JSON => subscriber.json().init(),
+        LoggingFormat::Standard => subscriber.init(),
+        LoggingFormat::Json => subscriber.json().init(),
     }
 }
 


### PR DESCRIPTION
## Overview

-   Allow SQLlite as a database backend so that users don't need to install/run Postgres locally. 
-  Specify the default option in Photon as an in-memory SQLite database.

## Testing

-   Added test fixtures for SQLlite so that now all tests are run with both postgres and SQLlite.