### PR TITLE
Add missing db README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cargo run
 // Against devnet
 cargo run -- --rpc-url=https://api.devnet.solana.com
 
-// Using your local Postgres database instead of the default in in-memory SQLlite db
+// Using your local Postgres database instead of the default in in-memory SQLite db
 cargon run -- --db-urlpostgres://postgres@localhost/postgres
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ cargo run
 
 // Against devnet
 cargo run -- --rpc-url=https://api.devnet.solana.com
+
+// Using your local Postgres database instead of the default in in-memory SQLlite db
+cargon run -- --db-urlpostgres://postgres@localhost/postgres
 ```
 
 To see configurations options run


### PR DESCRIPTION
## Overview

-   Added instructions for configuring database and mentioned that the default is an in-memory SQLite. Need to add functionality/instructions for running migrations on Postgres db. 

