### PR TITLE
Use main branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,16 +15,17 @@ dependencies = [
 [[package]]
 name = "account-compression"
 version = "0.3.1"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
+source = "git+https://github.com/Lightprotocol/light-protocol.git?rev=58edd1c241e79bda452f9a49e52c41cb6358f0a2#58edd1c241e79bda452f9a49e52c41cb6358f0a2"
 dependencies = [
  "account-compression-state",
  "ahash 0.8.6",
  "aligned-sized",
  "anchor-lang",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
+ "ark-ff",
+ "ark-serialize",
  "borsh 0.10.3",
  "bytemuck",
+ "light-bounded-vec",
  "light-concurrent-merkle-tree",
  "light-hasher",
  "light-indexed-merkle-tree",
@@ -36,9 +37,10 @@ dependencies = [
 [[package]]
 name = "account-compression-state"
 version = "0.1.0"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
+source = "git+https://github.com/Lightprotocol/light-protocol.git?rev=58edd1c241e79bda452f9a49e52c41cb6358f0a2#58edd1c241e79bda452f9a49e52c41cb6358f0a2"
 dependencies = [
- "ark-ff 0.4.2",
+ "ark-ff",
+ "light-concurrent-merkle-tree",
  "light-hasher",
  "light-indexed-merkle-tree",
 ]
@@ -136,7 +138,7 @@ checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 [[package]]
 name = "aligned-sized"
 version = "0.1.0"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
+source = "git+https://github.com/Lightprotocol/light-protocol.git?rev=58edd1c241e79bda452f9a49e52c41cb6358f0a2#58edd1c241e79bda452f9a49e52c41cb6358f0a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -404,70 +406,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
-name = "ark-bls12-381"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65be532f9dd1e98ad0150b037276cde464c6f371059e6dd02c0222395761f6aa"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
-]
-
-[[package]]
-name = "ark-bn254"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea691771ebbb28aea556c044e2e5c5227398d840cee0c34d4d20fa8eb2689e8c"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
-]
-
-[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
 dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
-]
-
-[[package]]
-name = "ark-crypto-primitives"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff773c0ef8c655c98071d3026a63950798a66b2f45baef22d8334c1756f1bd18"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-nonnative-field",
- "ark-r1cs-std",
- "ark-relations",
- "ark-serialize 0.3.0",
- "ark-snark",
- "ark-std 0.3.0",
- "blake2",
- "derivative",
- "digest 0.9.0",
- "tracing",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea978406c4b1ca13c2db2373b05cc55429c3575b8b21f1b9ee859aa5b03dd42"
-dependencies = [
- "ark-ff 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "num-traits",
- "zeroize",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -476,58 +422,14 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff 0.4.2",
- "ark-poly 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
  "num-traits",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ed-on-bls12-381"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b7ada17db3854f5994e74e60b18e10e818594935ee7e1d329800c117b32970"
-dependencies = [
- "ark-bls12-381",
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-r1cs-std",
- "ark-std 0.3.0",
-]
-
-[[package]]
-name = "ark-ed-on-bn254"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdc786b806fdbff4abebb08ec2fcb50cfe3941918e57120ab121228452903fd"
-dependencies = [
- "ark-bn254 0.3.0",
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-r1cs-std",
- "ark-std 0.3.0",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
-dependencies = [
- "ark-ff-asm 0.3.0",
- "ark-ff-macros 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "num-bigint 0.4.4",
- "num-traits",
- "paste",
- "rustc_version 0.3.3",
  "zeroize",
 ]
 
@@ -537,28 +439,18 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
  "num-bigint 0.4.4",
  "num-traits",
  "paste",
- "rustc_version 0.4.0",
+ "rustc_version",
  "zeroize",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
-dependencies = [
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -567,18 +459,6 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
-dependencies = [
- "num-bigint 0.4.4",
- "num-traits",
  "quote",
  "syn 1.0.109",
 ]
@@ -597,134 +477,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-groth16"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f8fff7468e947130b5caf9bdd27de8b913cf30e15104b4f0cd301726b3d897"
-dependencies = [
- "ark-crypto-primitives",
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-poly 0.3.0",
- "ark-relations",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
-]
-
-[[package]]
-name = "ark-marlin"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa8510faa8e64f0a6841ee4b58efe2d56f7a80d86fa0ce9891bbb3aa20166d9"
-dependencies = [
- "ark-ff 0.3.0",
- "ark-poly 0.3.0",
- "ark-poly-commit",
- "ark-relations",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "digest 0.9.0",
- "rand_chacha 0.3.1",
-]
-
-[[package]]
-name = "ark-nonnative-field"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440ad4569974910adbeb84422b7e622b79e08d27142afd113785b7fcfb446186"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-r1cs-std",
- "ark-relations",
- "ark-std 0.3.0",
- "derivative",
- "num-bigint 0.4.4",
- "num-integer",
- "num-traits",
- "tracing",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0f78f47537c2f15706db7e98fe64cc1711dbf9def81218194e17239e53e5aa"
-dependencies = [
- "ark-ff 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "hashbrown 0.11.2",
-]
-
-[[package]]
 name = "ark-poly"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "ark-poly-commit"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71ddfa72bad1446cab7bbecb6018dbbdc9abcbc3a0065483ae5186ad2a64dcd"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-poly 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "digest 0.9.0",
- "tracing",
-]
-
-[[package]]
-name = "ark-r1cs-std"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e8fdacb1931f238a0d866ced1e916a49d36de832fd8b83dc916b718ae72893"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-relations",
- "ark-std 0.3.0",
- "derivative",
- "num-bigint 0.4.4",
- "num-traits",
- "tracing",
-]
-
-[[package]]
-name = "ark-relations"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cba4c1c99792a6834bd97f7fd76578ec2cd58d2afc5139a17e1d1bec65b38f6"
-dependencies = [
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
- "tracing",
- "tracing-subscriber 0.2.25",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
-dependencies = [
- "ark-serialize-derive 0.3.0",
- "ark-std 0.3.0",
- "digest 0.9.0",
 ]
 
 [[package]]
@@ -733,21 +495,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive 0.4.2",
- "ark-std 0.4.0",
+ "ark-serialize-derive",
+ "ark-std",
  "digest 0.10.7",
  "num-bigint 0.4.4",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd4e5f0bf8285d5ed538d27fab7411f3e297908fd93c62195de8bee3f199e82"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -762,27 +513,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-snark"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc3dff1a5f67a9c0b34df32b079752d8dd17f1e9d06253da0453db6c1b7cc8a"
-dependencies = [
- "ark-ff 0.3.0",
- "ark-relations",
- "ark-std 0.3.0",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "ark-std"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,33 +520,6 @@ checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
-]
-
-[[package]]
-name = "arkworks-gadgets"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5e1a19f9135545de34eb3f3d061f8e5c4072aadd5f09c56d357647a66d509a"
-dependencies = [
- "ark-bls12-381",
- "ark-bn254 0.3.0",
- "ark-crypto-primitives",
- "ark-ec 0.3.0",
- "ark-ed-on-bls12-381",
- "ark-ed-on-bn254",
- "ark-ff 0.3.0",
- "ark-groth16",
- "ark-marlin",
- "ark-poly 0.3.0",
- "ark-poly-commit",
- "ark-r1cs-std",
- "ark-relations",
- "ark-serialize 0.3.0",
- "ark-snark",
- "ark-std 0.3.0",
- "blake2",
- "digest 0.9.0",
- "paste",
 ]
 
 [[package]]
@@ -1244,17 +947,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "blake2"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -2626,19 +2318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "groth16-solana"
-version = "0.0.2"
-source = "git+https://github.com/Lightprotocol/groth16-solana?branch=master#d1165a03aed6150576c38160797c9f9a1ae630a1"
-dependencies = [
- "ark-bn254 0.4.0",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "solana-program",
- "thiserror",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3284,12 +2963,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "light-concurrent-merkle-tree"
+name = "light-bounded-vec"
 version = "0.1.0"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
+source = "git+https://github.com/Lightprotocol/light-protocol.git?rev=58edd1c241e79bda452f9a49e52c41cb6358f0a2#58edd1c241e79bda452f9a49e52c41cb6358f0a2"
 dependencies = [
  "bytemuck",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
+name = "light-concurrent-merkle-tree"
+version = "0.1.0"
+source = "git+https://github.com/Lightprotocol/light-protocol.git?rev=58edd1c241e79bda452f9a49e52c41cb6358f0a2#58edd1c241e79bda452f9a49e52c41cb6358f0a2"
+dependencies = [
+ "bytemuck",
+ "light-bounded-vec",
  "light-hasher",
+ "memoffset 0.8.0",
  "solana-program",
  "thiserror",
 ]
@@ -3297,9 +2988,9 @@ dependencies = [
 [[package]]
 name = "light-hasher"
 version = "0.1.0"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
+source = "git+https://github.com/Lightprotocol/light-protocol.git?rev=58edd1c241e79bda452f9a49e52c41cb6358f0a2#58edd1c241e79bda452f9a49e52c41cb6358f0a2"
 dependencies = [
- "ark-bn254 0.4.0",
+ "ark-bn254",
  "light-poseidon",
  "sha2 0.10.8",
  "sha3 0.10.8",
@@ -3310,21 +3001,23 @@ dependencies = [
 [[package]]
 name = "light-indexed-merkle-tree"
 version = "0.1.0"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
+source = "git+https://github.com/Lightprotocol/light-protocol.git?rev=58edd1c241e79bda452f9a49e52c41cb6358f0a2#58edd1c241e79bda452f9a49e52c41cb6358f0a2"
 dependencies = [
- "ark-ff 0.4.2",
+ "ark-ff",
  "borsh 0.10.3",
+ "light-bounded-vec",
  "light-concurrent-merkle-tree",
  "light-merkle-tree-reference",
  "light-utils",
  "num-traits",
+ "solana-program",
  "thiserror",
 ]
 
 [[package]]
 name = "light-macros"
 version = "0.3.1"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
+source = "git+https://github.com/Lightprotocol/light-protocol.git?rev=58edd1c241e79bda452f9a49e52c41cb6358f0a2#58edd1c241e79bda452f9a49e52c41cb6358f0a2"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -3335,52 +3028,19 @@ dependencies = [
 [[package]]
 name = "light-merkle-tree-event"
 version = "0.1.0"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
+source = "git+https://github.com/Lightprotocol/light-protocol.git?rev=58edd1c241e79bda452f9a49e52c41cb6358f0a2#58edd1c241e79bda452f9a49e52c41cb6358f0a2"
 dependencies = [
  "borsh 0.10.3",
  "light-concurrent-merkle-tree",
- "num-derive 0.4.2",
- "num-traits",
- "solana-program",
  "thiserror",
-]
-
-[[package]]
-name = "light-merkle-tree-program"
-version = "0.3.1"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
-dependencies = [
- "ahash 0.8.6",
- "aligned-sized",
- "anchor-lang",
- "anchor-spl",
- "ark-bn254 0.3.0",
- "ark-crypto-primitives",
- "ark-ec 0.3.0",
- "ark-ed-on-bn254",
- "ark-ff 0.3.0",
- "ark-relations",
- "ark-std 0.3.0",
- "arkworks-gadgets",
- "arrayref",
- "bincode",
- "bytemuck",
- "byteorder",
- "getrandom 0.2.12",
- "light-concurrent-merkle-tree",
- "light-hasher",
- "light-macros",
- "light-merkle-tree-event",
- "light-utils",
- "solana-security-txt",
- "spl-token 3.5.0",
 ]
 
 [[package]]
 name = "light-merkle-tree-reference"
 version = "0.1.0"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
+source = "git+https://github.com/Lightprotocol/light-protocol.git?rev=58edd1c241e79bda452f9a49e52c41cb6358f0a2#58edd1c241e79bda452f9a49e52c41cb6358f0a2"
 dependencies = [
+ "light-bounded-vec",
  "light-hasher",
  "thiserror",
 ]
@@ -3391,8 +3051,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
 dependencies = [
- "ark-bn254 0.4.0",
- "ark-ff 0.4.2",
+ "ark-bn254",
+ "ark-ff",
  "num-bigint 0.4.4",
  "thiserror",
 ]
@@ -3400,32 +3060,13 @@ dependencies = [
 [[package]]
 name = "light-utils"
 version = "0.1.0"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
+source = "git+https://github.com/Lightprotocol/light-protocol.git?rev=58edd1c241e79bda452f9a49e52c41cb6358f0a2#58edd1c241e79bda452f9a49e52c41cb6358f0a2"
 dependencies = [
  "anyhow",
- "ark-bn254 0.4.0",
- "ark-ff 0.4.2",
+ "ark-bn254",
+ "ark-ff",
  "solana-program",
  "thiserror",
-]
-
-[[package]]
-name = "light-verifier-sdk"
-version = "0.3.1"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
-dependencies = [
- "aligned-sized",
- "anchor-lang",
- "anchor-spl",
- "ark-bn254 0.3.0",
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
- "groth16-solana",
- "light-macros",
- "light-merkle-tree-program",
- "light-utils",
- "spl-token 3.5.0",
 ]
 
 [[package]]
@@ -3504,6 +3145,15 @@ name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -3996,17 +3646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest"
-version = "2.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
-dependencies = [
- "memchr",
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
 name = "photon"
 version = "0.1.0"
 dependencies = [
@@ -4053,7 +3692,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4246,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "psp-compressed-pda"
 version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
+source = "git+https://github.com/Lightprotocol/light-protocol.git?rev=58edd1c241e79bda452f9a49e52c41cb6358f0a2#58edd1c241e79bda452f9a49e52c41cb6358f0a2"
 dependencies = [
  "account-compression",
  "ahash 0.8.6",
@@ -4256,14 +3895,13 @@ dependencies = [
  "light-concurrent-merkle-tree",
  "light-hasher",
  "light-utils",
- "light-verifier-sdk",
  "solana-sdk",
 ]
 
 [[package]]
 name = "psp-compressed-token"
 version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-protocol.git?branch=emit-indexable-for-photon#a2d7471b2c7ee44635111154baa84c8a7b1279ca"
+source = "git+https://github.com/Lightprotocol/light-protocol.git?rev=58edd1c241e79bda452f9a49e52c41cb6358f0a2#58edd1c241e79bda452f9a49e52c41cb6358f0a2"
 dependencies = [
  "account-compression",
  "ahash 0.8.6",
@@ -4704,7 +4342,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "rstest_macros",
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -4719,7 +4357,7 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "rustc_version 0.4.0",
+ "rustc_version",
  "syn 2.0.52",
  "unicode-ident",
 ]
@@ -4764,20 +4402,11 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.22",
+ "semver",
 ]
 
 [[package]]
@@ -4993,7 +4622,7 @@ dependencies = [
  "regex",
  "sea-schema",
  "tracing",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -5023,7 +4652,7 @@ dependencies = [
  "sea-orm-cli",
  "sea-schema",
  "tracing",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5144,27 +4773,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -5579,7 +5190,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memmap2",
- "rustc_version 0.4.0",
+ "rustc_version",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -5598,7 +5209,7 @@ checksum = "296e4cf0e2479e4c21afe4d17e32526f71f1bcd93b1c7c660900bc3e4233447a"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
+ "rustc_version",
  "syn 2.0.52",
 ]
 
@@ -5679,7 +5290,7 @@ dependencies = [
  "nix",
  "rand 0.8.5",
  "rayon",
- "rustc_version 0.4.0",
+ "rustc_version",
  "serde",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
@@ -5695,10 +5306,10 @@ version = "1.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e3a3b9623f09e2c480b4e129c92d7a036f8614fd0fc7519791bd44e64061ce8"
 dependencies = [
- "ark-bn254 0.4.0",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
  "base64 0.21.7",
  "bincode",
  "bitflags 2.4.2",
@@ -5726,7 +5337,7 @@ dependencies = [
  "num-traits",
  "parking_lot 0.12.1",
  "rand 0.8.5",
- "rustc_version 0.4.0",
+ "rustc_version",
  "rustversion",
  "serde",
  "serde_bytes",
@@ -5760,7 +5371,7 @@ dependencies = [
  "num-traits",
  "percentage",
  "rand 0.8.5",
- "rustc_version 0.4.0",
+ "rustc_version",
  "serde",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
@@ -5781,7 +5392,7 @@ dependencies = [
  "futures-util",
  "log",
  "reqwest",
- "semver 1.0.22",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5846,7 +5457,7 @@ dependencies = [
  "num-traits",
  "parking_lot 0.12.1",
  "qstring",
- "semver 1.0.22",
+ "semver",
  "solana-sdk",
  "thiserror",
  "uriparse",
@@ -5865,7 +5476,7 @@ dependencies = [
  "indicatif",
  "log",
  "reqwest",
- "semver 1.0.22",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5888,7 +5499,7 @@ dependencies = [
  "bs58 0.4.0",
  "jsonrpc-core",
  "reqwest",
- "semver 1.0.22",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5948,7 +5559,7 @@ dependencies = [
  "qualifier_attr",
  "rand 0.7.3",
  "rand 0.8.5",
- "rustc_version 0.4.0",
+ "rustc_version",
  "rustversion",
  "serde",
  "serde_bytes",
@@ -6104,8 +5715,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b32cc394aa7132ab7f270801b98bf47fa585ab93f1038e5be27e480d7b5b2dca"
 dependencies = [
  "log",
- "rustc_version 0.4.0",
- "semver 1.0.22",
+ "rustc_version",
+ "semver",
  "serde",
  "serde_derive",
  "solana-frozen-abi",
@@ -6123,7 +5734,7 @@ dependencies = [
  "log",
  "num-derive 0.3.3",
  "num-traits",
- "rustc_version 0.4.0",
+ "rustc_version",
  "serde",
  "serde_derive",
  "solana-frozen-abi",
@@ -7090,15 +6701,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
@@ -7150,12 +6752,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,15 @@ itertools = "0.12.1"
 jsonrpsee = {version = "0.16.2", features = ["server", "macros"]}
 jsonrpsee-core = {version = "0.16.2", features = ["server"]}
 lazy_static = "1.4.0"
-light-merkle-tree-event = {git = "https://github.com/Lightprotocol/light-protocol.git", branch = "emit-indexable-for-photon"}
+# 58edd1c241e79bda452f9a49e52c41cb6358f0a2
+light-merkle-tree-event = {git = "https://github.com/Lightprotocol/light-protocol.git", rev = "58edd1c241e79bda452f9a49e52c41cb6358f0a2"}
 light-poseidon = "0.2.0"
 log = "0.4.17"
 once_cell = "1.19.0"
 open-rpc-derive = {version = "0.0.4"}
 open-rpc-schema = {version = "0.0.4"}
-psp-compressed-pda = {git = "https://github.com/Lightprotocol/light-protocol.git", branch = "emit-indexable-for-photon"}
-psp-compressed-token = {git = "https://github.com/Lightprotocol/light-protocol.git", branch = "emit-indexable-for-photon"}
+psp-compressed-pda = {git = "https://github.com/Lightprotocol/light-protocol.git", rev = "58edd1c241e79bda452f9a49e52c41cb6358f0a2"}
+psp-compressed-token = {git = "https://github.com/Lightprotocol/light-protocol.git", rev = "58edd1c241e79bda452f9a49e52c41cb6358f0a2"}
 rstest = "0.18.2"
 schemars = {version = "0.8.6", features = ["chrono"]}
 schemars_derive = "0.8.6"

--- a/README.md
+++ b/README.md
@@ -25,21 +25,6 @@ cd photon
 cargo run --help
 ```
 
-## Setup
-
-To be able to compile dependencies please run:
-
-```
-echo """
-[net]
-git-fetch-with-cli = true
-""" >> ~/.cargo/config.toml
-```
-
-We need to use the Git cli in order to be able to use ssh authentication and download the gnark-prover
-submodule from the Light repo that's specified through an ssh url. This setup step is temporary
-until Light publishes the packages to crates.io or removes the grank-prover submodule. 
-
 ## Database
 
 Photon uses Postgres and the schema is managed by SeaORM. The database is managed via migrations. 

--- a/src/ingester/persist/mod.rs
+++ b/src/ingester/persist/mod.rs
@@ -239,7 +239,6 @@ pub async fn persist_token_data(
         state,
         is_native,
         delegated_amount,
-        close_authority,
     } = token_tlv_data;
 
     let model = token_owners::ActiveModel {
@@ -250,7 +249,7 @@ pub async fn persist_token_data(
         frozen: Set(state == AccountState::Frozen),
         delegated_amount: Set(delegated_amount as i64),
         is_native: Set(is_native.map(|n| n as i64)),
-        close_authority: Set(close_authority.map(|c| c.to_bytes().to_vec())),
+        // TODO: Add close authority
         ..Default::default()
     };
     // TODO: We are not addressing the case where the record already exists.

--- a/tests/integration_tests/persist_tests.rs
+++ b/tests/integration_tests/persist_tests.rs
@@ -168,7 +168,6 @@ async fn test_persist_token_data(
         state: AccountState::Frozen,
         is_native: Some(1),
         delegated_amount: 0,
-        close_authority: Some(Pubkey::new_unique()),
     };
 
     let token_tlv_data2: TokenTlvData = TokenTlvData {
@@ -179,7 +178,6 @@ async fn test_persist_token_data(
         state: AccountState::Initialized,
         is_native: None,
         delegated_amount: 1,
-        close_authority: None,
     };
 
     let token_tlv_data3: TokenTlvData = TokenTlvData {
@@ -190,7 +188,6 @@ async fn test_persist_token_data(
         state: AccountState::Frozen,
         is_native: Some(1000),
         delegated_amount: 0,
-        close_authority: Some(Pubkey::new_unique()),
     };
     for token_tlv_data in vec![
         token_tlv_data1.clone(),
@@ -233,12 +230,6 @@ async fn test_persist_token_data(
         token_tlv_data1.delegate.map(SerializablePubkey::from)
     );
     assert_eq!(res.is_native, true);
-    assert_eq!(
-        res.close_authority,
-        token_tlv_data1
-            .close_authority
-            .map(SerializablePubkey::from)
-    );
 
     let res = setup
         .api


### PR DESCRIPTION
## Overview

- Use main branch instead of `emit-indexeable-event` to avoid installing hard-to-install submodule. 
- Use a fixed commit to avoid breaking changes.

## Testing

-  Cargo test
