### PR TITLE
Clean up code debt (part 1)

### DIFF
--- a/src/api/method/utils.rs
+++ b/src/api/method/utils.rs
@@ -11,24 +11,26 @@ use super::super::error::PhotonApiError;
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Utxo {
     pub hash: Hash,
-    pub account: Option<SerializablePubkey>,
-    pub owner: SerializablePubkey,
+    pub address: Option<SerializablePubkey>,
     pub data: String,
-    pub tree: Option<SerializablePubkey>,
+    pub owner: SerializablePubkey,
     pub lamports: u64,
-    pub slot_created: u64,
+    pub tree: Option<SerializablePubkey>,
+    pub seq: Option<u64>,
+    pub slot_updated: u64,
 }
 
 pub fn parse_utxo_model(utxo: utxos::Model) -> Result<Utxo, PhotonApiError> {
     Ok(Utxo {
         hash: utxo.hash.try_into()?,
-        account: utxo.account.map(SerializablePubkey::try_from).transpose()?,
+        address: utxo.account.map(SerializablePubkey::try_from).transpose()?,
         #[allow(deprecated)]
         data: base64::encode(utxo.data),
         owner: utxo.owner.try_into()?,
         tree: utxo.tree.map(|tree| tree.try_into()).transpose()?,
         lamports: utxo.lamports as u64,
-        slot_created: utxo.slot_updated as u64,
+        slot_updated: utxo.slot_updated as u64,
+        seq: utxo.seq.map(|seq| seq as u64),
     })
 }
 

--- a/src/dao/typedefs/hash.rs
+++ b/src/dao/typedefs/hash.rs
@@ -77,7 +77,6 @@ impl Into<[u8; 32]> for Hash {
     }
 }
 
-
 impl TryFrom<Vec<u8>> for Hash {
     type Error = ParseHashError;
 

--- a/src/dao/typedefs/serializable_pubkey.rs
+++ b/src/dao/typedefs/serializable_pubkey.rs
@@ -25,6 +25,12 @@ impl TryFrom<&str> for SerializablePubkey {
     }
 }
 
+impl fmt::Display for SerializablePubkey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
 impl From<SolanaPubkey> for SerializablePubkey {
     fn from(pubkey: SolanaPubkey) -> Self {
         SerializablePubkey(pubkey)

--- a/tests/integration_tests/persist_tests.rs
+++ b/tests/integration_tests/persist_tests.rs
@@ -6,7 +6,6 @@ use photon::api::api::ApiContract;
 use photon::api::{
     error::PhotonApiError,
     method::{
-        get_compressed_account::GetCompressedAccountRequest,
         get_compressed_token_accounts_by_owner::GetCompressedTokenInfoByOwnerRequest,
         get_utxo::GetUtxoRequest,
     },
@@ -99,22 +98,6 @@ async fn test_persist_state_transitions(
     };
     persist_bundle(&setup.db_conn, bundle.into()).await.unwrap();
 
-    // Verify GetCompressedAccount
-    let res = setup
-        .api
-        .get_compressed_account(GetCompressedAccountRequest {
-            hash: Some(Hash::from(hash.clone())),
-            ..Default::default()
-        })
-        .await
-        .unwrap()
-        .unwrap();
-
-    #[allow(deprecated)]
-    let raw_data = base64::decode(res.data).unwrap();
-    assert_eq!(person_tlv, Tlv::try_from_slice(&raw_data).unwrap());
-    assert_eq!(res.lamports, utxo.lamports as i64);
-
     // Verify GetUtxo
     let res = setup
         .api
@@ -128,7 +111,7 @@ async fn test_persist_state_transitions(
     let raw_data = base64::decode(res.data).unwrap();
     assert_eq!(person_tlv, Tlv::try_from_slice(&raw_data).unwrap());
     assert_eq!(res.lamports, utxo.lamports);
-    assert_eq!(res.slot_created, slot as u64);
+    assert_eq!(res.slot_updated, slot as u64);
 
     // Assert that we get an error if we input a non-existent UTXO.
     // TODO: Test spent utxos


### PR DESCRIPTION
## Overview

-   Implemented the readiness method for the API 
-  Changed our APIs from `Result<Option<Value, ApiError>>` to just `Result<Value, ApiError>` and threw an error if an object was missing. 
- Removed the hash input to the `get_compressed_account` method. It was confusing. 

## Testing

-   Cargo test
