### PR TITLE
Index blocks instead of individual transactions

### DIFF
--- a/src/ingester/fetchers/poller.rs
+++ b/src/ingester/fetchers/poller.rs
@@ -14,7 +14,6 @@ pub struct TransactionPoller {
 
 pub struct Options {
     pub start_slot: u64,
-    pub max_block_fetching_concurrency: usize,
 }
 
 pub async fn fetch_current_slot_with_infinite_retry(client: &RpcClient) -> u64 {

--- a/src/ingester/fetchers/poller.rs
+++ b/src/ingester/fetchers/poller.rs
@@ -1,21 +1,15 @@
 use std::{sync::Arc, thread::sleep, time::Duration};
 
-use anyhow::{anyhow, Result};
 use futures::{stream, StreamExt};
 use solana_client::{nonblocking::rpc_client::RpcClient, rpc_config::RpcBlockConfig};
-use solana_sdk::{
-    clock::UnixTimestamp, commitment_config::CommitmentConfig, transaction::VersionedTransaction,
-};
-use solana_transaction_status::{
-    EncodedTransactionWithStatusMeta, TransactionDetails, UiConfirmedBlock, UiTransactionEncoding,
-};
+use solana_sdk::commitment_config::CommitmentConfig;
+use solana_transaction_status::{TransactionDetails, UiTransactionEncoding};
 
-use super::super::transaction_info::{parse_instruction_groups, TransactionInfo};
+use crate::ingester::typedefs::block_info::{parse_ui_confirmed_blocked, BlockInfo};
 
 pub struct TransactionPoller {
     client: Arc<RpcClient>,
     slot: u64,
-    max_block_fetching_concurrency: usize,
 }
 
 pub struct Options {
@@ -35,7 +29,7 @@ pub async fn fetch_current_slot_with_infinite_retry(client: &RpcClient) -> u64 {
     }
 }
 
-pub async fn fetch_block_with_infinite_retry(client: &RpcClient, slot: u64) -> UiConfirmedBlock {
+pub async fn fetch_block_with_infinite_retry(client: &RpcClient, slot: u64) -> BlockInfo {
     loop {
         match client
             .get_block_with_config(
@@ -51,7 +45,8 @@ pub async fn fetch_block_with_infinite_retry(client: &RpcClient, slot: u64) -> U
             )
             .await
         {
-            Ok(block) => return block,
+            // Panic if RPC does not return blocks in the expected format
+            Ok(block) => return parse_ui_confirmed_blocked(block, slot).unwrap(),
             Err(e) => {
                 log::error!("Failed to fetch block: {}", e);
                 sleep(Duration::from_secs(1));
@@ -61,84 +56,29 @@ pub async fn fetch_block_with_infinite_retry(client: &RpcClient, slot: u64) -> U
 }
 
 impl TransactionPoller {
-    #[allow(dead_code)]
     pub async fn new(client: Arc<RpcClient>, options: Options) -> Self {
         Self {
             client,
             slot: options.start_slot,
-            max_block_fetching_concurrency: options.max_block_fetching_concurrency,
         }
     }
 
-    async fn fetch_new_blocks(&mut self) -> Vec<(UiConfirmedBlock, u64)> {
+    pub async fn fetch_new_block_batch(&mut self, batch_size: usize) -> Vec<BlockInfo> {
         let new_slot = fetch_current_slot_with_infinite_retry(self.client.as_ref()).await;
         let slots: Vec<_> = (self.slot..new_slot).collect();
 
-        let blocks = stream::iter(slots)
+        let mut blocks: Vec<BlockInfo> = stream::iter(slots)
             .map(|slot| {
                 let slot = slot.clone();
                 let client = self.client.clone();
-                // TODO: Add retries for failed requests
-                async move {
-                    (
-                        fetch_block_with_infinite_retry(client.as_ref(), slot).await,
-                        slot,
-                    )
-                }
+                async move { fetch_block_with_infinite_retry(client.as_ref(), slot).await }
             })
-            .buffer_unordered(self.max_block_fetching_concurrency)
+            .buffer_unordered(batch_size)
             .collect()
             .await;
+        blocks.sort_by(|a, b| a.slot.cmp(&b.slot));
 
         self.slot = new_slot;
         blocks
     }
-
-    #[allow(dead_code)]
-    pub async fn fetch_new_transactions(&mut self) -> Vec<TransactionInfo> {
-        let mut transactions = vec![];
-        let new_blocks = self.fetch_new_blocks().await;
-
-        if new_blocks.len() == 0 {
-            sleep(Duration::from_millis(100));
-        }
-
-        for (block, slot) in new_blocks {
-            let block_time = block.block_time;
-            for transaction in block.transactions.unwrap_or(Vec::new()) {
-                let parsed_transaction = _parse_transaction(transaction, slot, block_time);
-                match parsed_transaction {
-                    Ok(transaction) => {
-                        transactions.push(transaction);
-                    }
-                    Err(e) => {
-                        log::error!("Failed to parse transaction: {}", e);
-                    }
-                }
-            }
-        }
-        transactions
-    }
-}
-
-fn _parse_transaction(
-    transaction: EncodedTransactionWithStatusMeta,
-    slot: u64,
-    block_time: Option<UnixTimestamp>,
-) -> Result<TransactionInfo> {
-    let EncodedTransactionWithStatusMeta {
-        transaction, meta, ..
-    } = transaction;
-    let versioned_transaction: VersionedTransaction = transaction
-        .decode()
-        .ok_or(anyhow!("Transaction cannot be decoded".to_string()))?;
-
-    let signature = versioned_transaction.signatures[0];
-    let instruction_groups = parse_instruction_groups(versioned_transaction, meta)?;
-    Ok(TransactionInfo {
-        slot: slot,
-        block_time: block_time,
-        instruction_groups,
-        signature,
-    })
 }

--- a/src/ingester/mod.rs
+++ b/src/ingester/mod.rs
@@ -1,49 +1,63 @@
-use std::sync::Arc;
+use std::thread::sleep;
+use std::time::Duration;
 
 use error::IngesterError;
-use futures::stream::Stream;
 use futures::stream::StreamExt;
 use futures::TryStreamExt;
 use parser::parse_transaction;
 use sea_orm::DatabaseConnection;
-use std::pin::Pin;
-use transaction_info::TransactionInfo;
+use sea_orm::DatabaseTransaction;
+use sea_orm::TransactionTrait;
+use typedefs::block_info::TransactionInfo;
+
+use self::typedefs::block_info::BlockInfo;
 pub mod error;
 pub mod fetchers;
 pub mod parser;
 pub mod persist;
-pub mod transaction_info;
+pub mod typedefs;
 
-pub async fn index_transaction(
-    db: &DatabaseConnection,
-    txn: TransactionInfo,
+async fn index_transaction(
+    txn: &DatabaseTransaction,
+    transaction_info: &TransactionInfo,
+    slot: u64,
 ) -> Result<(), IngesterError> {
-    let event_bundles = parse_transaction(txn)?;
+    let event_bundles = parse_transaction(transaction_info, slot)?;
     let stream = futures::stream::iter(event_bundles);
 
     // We use a default parameter to avoid parameter input overload. High concurrency is likely
     // ineffective due to database locking since the events in a transaction likely affect the same tree.
     let max_concurrent_calls = 5;
     stream
-        .map(|bundle| async { persist::persist_bundle(db, bundle).await })
+        .map(|bundle| async { persist::persist_bundle(txn, bundle).await })
         .buffer_unordered(max_concurrent_calls)
         .try_collect::<()>()
         .await
 }
 
-pub async fn index_transaction_stream(
-    db: Arc<DatabaseConnection>,
-    stream: Pin<Box<dyn Stream<Item = TransactionInfo> + Send>>,
-    max_concurrency: usize,
-) {
-    stream
-        .for_each_concurrent(max_concurrency, |sig| {
-            let db_clone = db.clone();
-            async move {
-                if let Err(e) = index_transaction(db_clone.as_ref(), sig).await {
-                    log::error!("Failed to index transaction: {}", e);
-                }
+pub async fn index_block(db: &DatabaseConnection, block: &BlockInfo) -> Result<(), IngesterError> {
+    let txn = db.begin().await?;
+    for transaction in &block.transactions {
+        index_transaction(&txn, &transaction, block.slot).await?;
+    }
+    txn.commit().await?;
+    Ok(())
+}
+
+pub async fn index_block_batch(db: &DatabaseConnection, block_batch: Vec<BlockInfo>) {
+    for block in block_batch {
+        index_block_with_infinite_retries(db, &block).await;
+    }
+}
+
+async fn index_block_with_infinite_retries(db: &DatabaseConnection, block: &BlockInfo) {
+    loop {
+        match index_block(db, &block).await {
+            Ok(()) => return (),
+            Err(e) => {
+                log::error!("Failed to index block: {}", e);
+                sleep(Duration::from_secs(1));
             }
-        })
-        .await;
+        }
+    }
 }

--- a/src/ingester/parser/mod.rs
+++ b/src/ingester/parser/mod.rs
@@ -6,7 +6,7 @@ use solana_sdk::pubkey::Pubkey;
 
 use super::{
     error::IngesterError, parser::bundle::PublicTransactionEventBundle,
-    transaction_info::TransactionInfo,
+    typedefs::block_info::TransactionInfo,
 };
 
 use self::bundle::EventBundle;
@@ -18,7 +18,10 @@ const ACCOUNT_COMPRESSION_PROGRAM_ID: Pubkey =
     pubkey!("5QPEJ5zDsVou9FQS3KCauKswM3VwBEBu4dpL9xTqkWwN");
 const NOOP_PROGRAM_ID: Pubkey = pubkey!("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
 
-pub fn parse_transaction(tx: TransactionInfo) -> Result<Vec<EventBundle>, IngesterError> {
+pub fn parse_transaction(
+    tx: &TransactionInfo,
+    slot: u64,
+) -> Result<Vec<EventBundle>, IngesterError> {
     let mut event_bundles = Vec::new();
     let mut logged_transaction = false;
     for instruction_group in tx.clone().instruction_groups {
@@ -41,7 +44,7 @@ pub fn parse_transaction(tx: TransactionInfo) -> Result<Vec<EventBundle>, Ingest
                     if !logged_transaction {
                         info!(
                             "Indexing transaction with slot {} and id {}",
-                            tx.slot, tx.signature
+                            slot, tx.signature
                         );
                         logged_transaction = true;
                     }
@@ -67,7 +70,7 @@ pub fn parse_transaction(tx: TransactionInfo) -> Result<Vec<EventBundle>, Ingest
                         in_utxos: public_transaction_event.in_utxos,
                         out_utxos: public_transaction_event.out_utxos,
                         changelogs: changelogs,
-                        slot: tx.slot,
+                        slot: slot,
                         transaction: tx.signature,
                     };
 

--- a/src/ingester/typedefs/mod.rs
+++ b/src/ingester/typedefs/mod.rs
@@ -1,0 +1,1 @@
+pub mod block_info;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,10 @@ use clap::{Parser, ValueEnum};
 use jsonrpsee::server::ServerHandle;
 use log::{error, info};
 use photon::api::{self, api::PhotonApi};
-use photon::ingester::{
-    fetchers::poller::{fetch_current_slot_with_infinite_retry, Options, TransactionPoller},
-    index_block_stream,
+use photon::ingester::fetchers::poller::{
+    fetch_current_slot_with_infinite_retry, Options, TransactionPoller,
 };
+use photon::ingester::index_block_batch;
 use photon::migration::{
     sea_orm::{DatabaseBackend, DatabaseConnection, SqlxPostgresConnector, SqlxSqliteConnector},
     Migrator, MigratorTrait,
@@ -81,7 +81,6 @@ async fn start_transaction_indexer(
     rpc_client: RpcClient,
     is_localnet: bool,
     start_slot: Option<u64>,
-    max_indexing_concurrency: u32,
 ) -> tokio::task::JoinHandle<()> {
     let rpc_client = Arc::new(rpc_client);
     tokio::spawn(async move {
@@ -91,20 +90,13 @@ async fn start_transaction_indexer(
             (None, true) => 0,
             (None, false) => fetch_current_slot_with_infinite_retry(rpc_client.as_ref()).await,
         };
-        let mut poller = TransactionPoller::new(
-            rpc_client,
-            Options {
-                start_slot,
-                // Indexing throughput is more influenced by concurrent transaction indexing than
-                // RPC block fetching. So just use a reasonable default here.
-                max_block_fetching_concurrency: 5,
-            },
-        )
-        .await;
+        let mut poller = TransactionPoller::new(rpc_client, Options { start_slot }).await;
 
         info!("Backfilling historical blocks...");
         let mut finished_backfill = false;
         loop {
+            // Indexing throughput is more influenced by concurrent transaction indexing than
+            // RPC block fetching. So just use a reasonable default here.
             let blocks = poller.fetch_new_block_batch(5).await;
             if blocks.is_empty() {
                 sleep(Duration::from_millis(20));
@@ -115,14 +107,8 @@ async fn start_transaction_indexer(
                 finished_backfill = true;
                 continue;
             }
-            let transactions = futures::stream::iter(transactions);
 
-            index_transaction_stream(
-                db.clone(),
-                Box::pin(transactions),
-                max_indexing_concurrency as usize,
-            )
-            .await;
+            index_block_batch(db.as_ref(), blocks).await;
         }
     })
 }
@@ -206,9 +192,6 @@ async fn main() {
         RpcClient::new(args.rpc_url),
         is_localnet,
         args.start_slot,
-        // Set the max number of concurrent transactions to the index to the number of db connections
-        // as we can concurrently index at most one transaction per db connection.
-        args.max_db_conn,
     )
     .await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use log::{error, info};
 use photon::api::{self, api::PhotonApi};
 use photon::ingester::{
     fetchers::poller::{fetch_current_slot_with_infinite_retry, Options, TransactionPoller},
-    index_transaction_stream,
+    index_block_stream,
 };
 use photon::migration::{
     sea_orm::{DatabaseBackend, DatabaseConnection, SqlxPostgresConnector, SqlxSqliteConnector},
@@ -105,8 +105,8 @@ async fn start_transaction_indexer(
         info!("Backfilling historical blocks...");
         let mut finished_backfill = false;
         loop {
-            let transactions = poller.fetch_new_transactions().await;
-            if transactions.is_empty() {
+            let blocks = poller.fetch_new_block_batch(5).await;
+            if blocks.is_empty() {
                 sleep(Duration::from_millis(20));
                 if !finished_backfill {
                     info!("Finished backfilling historical blocks...");

--- a/tests/integration_tests/parsing_tests.rs
+++ b/tests/integration_tests/parsing_tests.rs
@@ -34,7 +34,7 @@ async fn test_e2e_utxo_parsing(
     )
     .await;
 
-    let events = parse_transaction(tx, 0).unwrap();
+    let events = parse_transaction(&tx, 0).unwrap();
     assert_eq!(events.len(), 1);
     for event in events {
         persist_bundle_using_connection(setup.db_conn.as_ref(), event)
@@ -77,7 +77,7 @@ async fn test_e2e_token_mint(
     )
     .await;
 
-    let events = parse_transaction(tx, 0).unwrap();
+    let events = parse_transaction(&tx, 0).unwrap();
     assert_eq!(events.len(), 1);
     for event in events {
         persist_bundle_using_connection(&setup.db_conn.as_ref(), event)
@@ -133,7 +133,7 @@ async fn test_e2e_lamport_transfer(
     )
     .await;
 
-    let events = parse_transaction(tx, 0).unwrap();
+    let events = parse_transaction(&tx, 0).unwrap();
     assert_eq!(events.len(), 1);
     for event in events {
         persist_bundle_using_connection(&setup.db_conn, event)

--- a/tests/integration_tests/parsing_tests.rs
+++ b/tests/integration_tests/parsing_tests.rs
@@ -1,12 +1,9 @@
-use core::panic;
-
 use function_name::named;
 use photon::api::api::ApiContract;
 use photon::api::method::get_compressed_token_accounts_by_owner::GetCompressedTokenAccountsByOwnerRequest;
 use photon::api::method::get_utxos::GetUtxosRequest;
-use photon::dao::generated::{token_owners, utxos};
 use photon::dao::typedefs::serializable_pubkey::SerializablePubkey;
-use photon::ingester::{parser::parse_transaction, persist::persist_bundle};
+use photon::ingester::parser::parse_transaction;
 
 use crate::utils::*;
 use insta::assert_json_snapshot;
@@ -37,10 +34,12 @@ async fn test_e2e_utxo_parsing(
     )
     .await;
 
-    let events = parse_transaction(tx).unwrap();
+    let events = parse_transaction(tx, 0).unwrap();
     assert_eq!(events.len(), 1);
     for event in events {
-        persist_bundle(&setup.db_conn, event).await.unwrap();
+        persist_bundle_using_connection(setup.db_conn.as_ref(), event)
+            .await
+            .unwrap();
     }
     let utxos = setup
         .api
@@ -78,10 +77,12 @@ async fn test_e2e_token_mint(
     )
     .await;
 
-    let events = parse_transaction(tx).unwrap();
+    let events = parse_transaction(tx, 0).unwrap();
     assert_eq!(events.len(), 1);
     for event in events {
-        persist_bundle(&setup.db_conn, event).await.unwrap();
+        persist_bundle_using_connection(&setup.db_conn.as_ref(), event)
+            .await
+            .unwrap();
     }
 
     let owner = "GTP6qbHeRne8doYekYmzzYMTXAtHMtpzzguLg2LLNMeD";
@@ -132,10 +133,12 @@ async fn test_e2e_lamport_transfer(
     )
     .await;
 
-    let events = parse_transaction(tx).unwrap();
+    let events = parse_transaction(tx, 0).unwrap();
     assert_eq!(events.len(), 1);
     for event in events {
-        persist_bundle(&setup.db_conn, event).await.unwrap();
+        persist_bundle_using_connection(&setup.db_conn, event)
+            .await
+            .unwrap();
     }
 
     let owner1 = "A79DKmTDe8VzfRLti3wTi7mbJ9ENZtK7eBHtJ4QYCR2Y";

--- a/tests/integration_tests/persist_tests.rs
+++ b/tests/integration_tests/persist_tests.rs
@@ -14,7 +14,6 @@ use photon::api::{
 use photon::dao::generated::utxos;
 use photon::dao::typedefs::{hash::Hash, serializable_pubkey::SerializablePubkey};
 use photon::ingester::parser::bundle::PublicTransactionEventBundle;
-use photon::ingester::persist::persist_bundle;
 use photon::ingester::persist::persist_token_data;
 use psp_compressed_pda::{
     tlv::{Tlv, TlvDataElement},
@@ -98,7 +97,9 @@ async fn test_persist_state_transitions(
         transaction: Signature::new_unique(),
         slot: slot,
     };
-    persist_bundle(&setup.db_conn, bundle.into()).await.unwrap();
+    persist_bundle_using_connection(&setup.db_conn, bundle.into())
+        .await
+        .unwrap();
 
     // Verify GetUtxo
     let res = setup

--- a/tests/integration_tests/snapshots/integration_tests__parsing_tests__e2e_lamport_transfer-A79DKmTDe8VzfRLti3wTi7mbJ9ENZtK7eBHtJ4QYCR2Y-utxos.snap
+++ b/tests/integration_tests/snapshots/integration_tests__parsing_tests__e2e_lamport_transfer-A79DKmTDe8VzfRLti3wTi7mbJ9ENZtK7eBHtJ4QYCR2Y-utxos.snap
@@ -12,7 +12,7 @@ expression: utxos
       "lamports": 420000000,
       "tree": "5bdFnXU47QjzGpzHfXnxcEi5WXyxzEAZzd1vrE39bf1W",
       "seq": 2,
-      "slotUpdated": 46
+      "slotUpdated": 0
     }
   ]
 }

--- a/tests/integration_tests/utils.rs
+++ b/tests/integration_tests/utils.rs
@@ -1,17 +1,12 @@
 use std::{
     env,
-    iter::Zip,
     path::{Path, PathBuf},
     str::FromStr,
     sync::Mutex,
 };
 
-use photon::ingester::transaction_info::TransactionInfo;
 use photon::{
-    api::{
-        api::PhotonApi,
-        method::utils::{TokenAccountList, TokenUxto},
-    },
+    api::{api::PhotonApi, method::utils::TokenAccountList},
     ingester::{parser::bundle::EventBundle, persist::persist_bundle},
 };
 
@@ -25,6 +20,7 @@ use sea_orm::{
 };
 
 use photon::dao::typedefs::hash::Hash;
+use photon::ingester::typedefs::block_info::TransactionInfo;
 pub use rstest::rstest;
 use solana_client::{
     nonblocking::rpc_client::RpcClient, rpc_config::RpcTransactionConfig, rpc_request::RpcRequest,

--- a/tests/integration_tests/utils.rs
+++ b/tests/integration_tests/utils.rs
@@ -6,11 +6,14 @@ use std::{
     sync::Mutex,
 };
 
-use photon::api::{
-    api::PhotonApi,
-    method::utils::{TokenAccountList, TokenUxto},
-};
 use photon::ingester::transaction_info::TransactionInfo;
+use photon::{
+    api::{
+        api::PhotonApi,
+        method::utils::{TokenAccountList, TokenUxto},
+    },
+    ingester::{parser::bundle::EventBundle, persist::persist_bundle},
+};
 
 use once_cell::sync::Lazy;
 use photon::migration::{Migrator, MigratorTrait};
@@ -18,7 +21,7 @@ use psp_compressed_token::{AccountState, TokenTlvData};
 pub use sea_orm::DatabaseBackend;
 use sea_orm::{
     ConnectionTrait, DatabaseConnection, DbBackend, DbErr, ExecResult, SqlxPostgresConnector,
-    SqlxSqliteConnector, Statement,
+    SqlxSqliteConnector, Statement, TransactionTrait,
 };
 
 use photon::dao::typedefs::hash::Hash;
@@ -290,7 +293,7 @@ pub fn verify_responses_match_tlv_data(response: TokenAccountList, tlvs: Vec<Tok
     }
 
     let token_accounts = response.items;
-    for (account, tlv) in token_accounts.iter().zip(tlvs.iter()) {
+    for (account, tlv) in token_accounts.iter().zip(order_tlvs(tlvs).iter()) {
         let account = account.clone();
         let tlv = tlv.clone();
         assert_eq!(account.mint, tlv.mint.into());
@@ -301,4 +304,15 @@ pub fn verify_responses_match_tlv_data(response: TokenAccountList, tlvs: Vec<Tok
         assert_eq!(account.frozen, tlv.state == AccountState::Frozen);
         assert_eq!(account.is_native, tlv.is_native.is_some());
     }
+}
+
+/// Persist using a database connection instead of a transaction. Should only be use for tests.
+pub async fn persist_bundle_using_connection(
+    db: &DatabaseConnection,
+    bundle: EventBundle,
+) -> Result<(), sea_orm::DbErr> {
+    let txn = db.begin().await.unwrap();
+    persist_bundle(&txn, bundle).await.unwrap();
+    txn.commit().await.unwrap();
+    Ok(())
 }


### PR DESCRIPTION
## Overview

Change the indexing interface to take in blocks instead of transactions so that:
1. We can index faster by "compressing" all state changes
2. Provide stronger guarantees about the blocks we have indexed 

## Testing

-   Cargo test
