### PR TITLE
Improve compilation speed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,10 @@ tracing-subscriber = {version = "0.3.16", features = [
 [dev-dependencies]
 function_name = "0.3.0"
 serial_test = "2.0.0"
+
+[profile.dev]
+# Do not produce debug info for ~40% faster incremental compilation.
+debug = 0
+# Some standard library files already come precompiled with debuginfo. We strip it for faster linking
+# and smaller binaries.
+strip = "debuginfo"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.76.0"


### PR DESCRIPTION
## Overview

-   Removed Rustc version restriction that I previously added in the rust-toolchain.toml file. I am trying out the Nightly Rust compiler to test out parallel-frontend. Using parallel-frontend lead to a 25% end-to-end compile time improvement. But it's unstable and can see it causing issues. So it's not something that I'd heavily evangelize without trying out myself.
-  Removed debug info for the dev profile to improve incremental compile time. Nobody seems to use debuggers so there shouldn't be any downsides here. This improved both end-to-end compile and incremental compile time by about 40%.

After optimizations, end-to-end compile times take 40 seconds and incremental compile times take 3 seconds 🎉 . Concretely this means that when we add CI in the future, it will run pretty fast especially if we use more cores. Right now I am not adding CI because I am the only that's contributing to the project and there are no users. So there wouldn't be any issue if tests break.    

## Testing

-   Cargo test 
