### PR TITLE
Bug fixes and local development improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "photon-indexer"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anchor-lang",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "photon-indexer"
 publish = true
 readme = "README.md"
 repository = "https://github.com/helius-labs/photon"
-version = "0.7.0"
+version = "0.8.0"
 
 [[bin]]
 name = "photon"

--- a/src/api/method/get_health.rs
+++ b/src/api/method/get_health.rs
@@ -2,12 +2,11 @@ use sea_orm::DatabaseConnection;
 
 use solana_client::nonblocking::rpc_client::RpcClient;
 
-
 use super::super::error::PhotonApiError;
 use super::utils::Context;
 
 // TODO: Make this an environment variable.
-const HEALTH_CHECK_SLOT_DISTANCE: u64 = 5;
+const HEALTH_CHECK_SLOT_DISTANCE: i64 = 5;
 
 // TODO: Make sure that get_health formatting matches the Solana RPC formatting.
 pub async fn get_health(
@@ -20,9 +19,9 @@ pub async fn get_health(
         .await
         .map_err(|e| PhotonApiError::UnexpectedError(format!("RPC error: {}", e)))?;
 
-    let slots_behind = slot - context.slot;
+    let slots_behind = slot as i64 - context.slot as i64;
     if slots_behind > HEALTH_CHECK_SLOT_DISTANCE {
-        return Err(PhotonApiError::StaleSlot(slots_behind));
+        return Err(PhotonApiError::StaleSlot(slots_behind as u64));
     }
     Ok("ok".to_string())
 }

--- a/src/api/method/utils.rs
+++ b/src/api/method/utils.rs
@@ -319,9 +319,9 @@ pub async fn fetch_token_accounts(
         .await?
         .drain(..)
         .map(|(token_account, account)| {
-            let account = account.ok_or(PhotonApiError::RecordNotFound(format!(
-                "Base account not found for token account",
-            )))?;
+            let account = account.ok_or(PhotonApiError::RecordNotFound(
+                "Base account not found for token account".to_string(),
+            ))?;
             Ok(EnrichedTokenAccountModel {
                 id: token_account.id,
                 hash: token_account.hash,

--- a/src/api/rpc_server.rs
+++ b/src/api/rpc_server.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
 
 use hyper::Method;
 use jsonrpsee::{
@@ -6,16 +6,18 @@ use jsonrpsee::{
     RpcModule,
 };
 use log::debug;
+use tokio::sync::Mutex;
 use tower_http::cors::{Any, CorsLayer};
 
-use super::api::PhotonApi;
-use super::method::{
-    get_compressed_accounts_by_owner::GetCompressedAccountsByOwnerRequest,
-    get_multiple_compressed_accounts::GetMultipleCompressedAccountsRequest,
-    utils::CompressedAccountRequest,
-};
+use crate::ingester::indexer::Indexer;
 
-pub async fn run_server(api: PhotonApi, port: u16) -> Result<ServerHandle, anyhow::Error> {
+use super::api::PhotonApi;
+
+pub async fn run_server(
+    api: PhotonApi,
+    port: u16,
+    indexer: Option<Arc<Mutex<Indexer>>>,
+) -> Result<ServerHandle, anyhow::Error> {
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let cors = CorsLayer::new()
         .allow_methods([Method::POST, Method::GET])
@@ -29,29 +31,45 @@ pub async fn run_server(api: PhotonApi, port: u16) -> Result<ServerHandle, anyho
         .set_middleware(middleware)
         .build(addr)
         .await?;
-    let rpc_module = build_rpc_module(api)?;
+    let rpc_module = build_rpc_module(ApiAndIndexer { api, indexer })?;
     server.start(rpc_module).map_err(|e| anyhow::anyhow!(e))
 }
 
-pub fn build_rpc_module(contract: PhotonApi) -> Result<RpcModule<PhotonApi>, anyhow::Error> {
-    let mut module = RpcModule::new(contract);
+struct ApiAndIndexer {
+    api: PhotonApi,
+    indexer: Option<Arc<Mutex<Indexer>>>,
+}
+
+async fn conditionally_index_latest_blocks(indexer: &Option<Arc<Mutex<Indexer>>>) {
+    if let Some(indexer) = indexer {
+        indexer.lock().await.index_latest_blocks(None).await;
+    }
+}
+
+fn build_rpc_module(
+    api_and_indexer: ApiAndIndexer,
+) -> Result<RpcModule<ApiAndIndexer>, anyhow::Error> {
+    let mut module = RpcModule::new(api_and_indexer);
 
     module.register_async_method("liveness", |_rpc_params, rpc_context| async move {
         debug!("Checking Liveness");
-        rpc_context.liveness().await.map_err(Into::into)
+        let ApiAndIndexer { api, .. } = rpc_context.as_ref();
+        api.liveness().await.map_err(Into::into)
     })?;
 
     module.register_async_method("readiness", |_rpc_params, rpc_context| async move {
         debug!("Checking Readiness");
-        rpc_context.readiness().await.map_err(Into::into)
+        let ApiAndIndexer { api, .. } = rpc_context.as_ref();
+        api.readiness().await.map_err(Into::into)
     })?;
 
     module.register_async_method(
         "getCompressedAccount",
         |rpc_params, rpc_context| async move {
+            let ApiAndIndexer { api, indexer } = rpc_context.as_ref();
+            conditionally_index_latest_blocks(indexer).await;
             let payload = rpc_params.parse()?;
-            rpc_context
-                .get_compressed_account(payload)
+            api.get_compressed_account(payload)
                 .await
                 .map_err(Into::into)
         },
@@ -60,9 +78,10 @@ pub fn build_rpc_module(contract: PhotonApi) -> Result<RpcModule<PhotonApi>, any
     module.register_async_method(
         "getCompressedAccountProof",
         |rpc_params, rpc_context| async move {
+            let ApiAndIndexer { api, indexer } = rpc_context.as_ref();
+            conditionally_index_latest_blocks(indexer).await;
             let payload = rpc_params.parse()?;
-            rpc_context
-                .get_compressed_account_proof(payload)
+            api.get_compressed_account_proof(payload)
                 .await
                 .map_err(Into::into)
         },
@@ -71,9 +90,10 @@ pub fn build_rpc_module(contract: PhotonApi) -> Result<RpcModule<PhotonApi>, any
     module.register_async_method(
         "getMultipleCompressedAccountProofs",
         |rpc_params, rpc_context| async move {
+            let ApiAndIndexer { api, indexer } = rpc_context.as_ref();
+            conditionally_index_latest_blocks(indexer).await;
             let payload = rpc_params.parse()?;
-            rpc_context
-                .get_multiple_compressed_account_proofs(payload)
+            api.get_multiple_compressed_account_proofs(payload)
                 .await
                 .map_err(Into::into)
         },
@@ -82,9 +102,10 @@ pub fn build_rpc_module(contract: PhotonApi) -> Result<RpcModule<PhotonApi>, any
     module.register_async_method(
         "getCompressedTokenAccountsByOwner",
         |rpc_params, rpc_context| async move {
+            let ApiAndIndexer { api, indexer } = rpc_context.as_ref();
+            conditionally_index_latest_blocks(indexer).await;
             let payload = rpc_params.parse()?;
-            rpc_context
-                .get_compressed_token_accounts_by_owner(payload)
+            api.get_compressed_token_accounts_by_owner(payload)
                 .await
                 .map_err(Into::into)
         },
@@ -93,9 +114,10 @@ pub fn build_rpc_module(contract: PhotonApi) -> Result<RpcModule<PhotonApi>, any
     module.register_async_method(
         "getCompressedTokenAccountsByDelegate",
         |rpc_params, rpc_context| async move {
+            let ApiAndIndexer { api, indexer } = rpc_context.as_ref();
+            conditionally_index_latest_blocks(indexer).await;
             let payload = rpc_params.parse()?;
-            rpc_context
-                .get_compressed_token_accounts_by_delegate(payload)
+            api.get_compressed_token_accounts_by_delegate(payload)
                 .await
                 .map_err(Into::into)
         },
@@ -104,9 +126,10 @@ pub fn build_rpc_module(contract: PhotonApi) -> Result<RpcModule<PhotonApi>, any
     module.register_async_method(
         "getCompressedTokenAccountBalance",
         |rpc_params, rpc_context| async move {
-            let payload = rpc_params.parse::<CompressedAccountRequest>()?;
-            rpc_context
-                .get_compressed_token_account_balance(payload)
+            let ApiAndIndexer { api, indexer } = rpc_context.as_ref();
+            conditionally_index_latest_blocks(indexer).await;
+            let payload = rpc_params.parse()?;
+            api.get_compressed_token_account_balance(payload)
                 .await
                 .map_err(Into::into)
         },
@@ -115,28 +138,32 @@ pub fn build_rpc_module(contract: PhotonApi) -> Result<RpcModule<PhotonApi>, any
     module.register_async_method(
         "getCompressedBalance",
         |rpc_params, rpc_context| async move {
-            let payload = rpc_params.parse::<CompressedAccountRequest>()?;
-            rpc_context
-                .get_compressed_balance(payload)
+            let ApiAndIndexer { api, indexer } = rpc_context.as_ref();
+            conditionally_index_latest_blocks(indexer).await;
+            let payload = rpc_params.parse()?;
+            api.get_compressed_balance(payload)
                 .await
                 .map_err(Into::into)
         },
     )?;
 
     module.register_async_method("getHealth", |_rpc_params, rpc_context| async move {
-        rpc_context.get_health().await.map_err(Into::into)
+        rpc_context.api.get_health().await.map_err(Into::into)
     })?;
 
     module.register_async_method("getSlot", |_rpc_params, rpc_context| async move {
-        rpc_context.get_slot().await.map_err(Into::into)
+        let ApiAndIndexer { api, indexer } = rpc_context.as_ref();
+        conditionally_index_latest_blocks(indexer).await;
+        api.get_slot().await.map_err(Into::into)
     })?;
 
     module.register_async_method(
-        "getCompressedProgramAccounts",
+        "getCompressedAccountsByOwner",
         |rpc_params, rpc_context| async move {
-            let payload = rpc_params.parse::<GetCompressedAccountsByOwnerRequest>()?;
-            rpc_context
-                .get_compressed_accounts_by_owner(payload)
+            let ApiAndIndexer { api, indexer } = rpc_context.as_ref();
+            conditionally_index_latest_blocks(indexer).await;
+            let payload = rpc_params.parse()?;
+            api.get_compressed_accounts_by_owner(payload)
                 .await
                 .map_err(Into::into)
         },
@@ -145,9 +172,10 @@ pub fn build_rpc_module(contract: PhotonApi) -> Result<RpcModule<PhotonApi>, any
     module.register_async_method(
         "getMultipleCompressedAccounts",
         |rpc_params, rpc_context| async move {
-            let payload = rpc_params.parse::<GetMultipleCompressedAccountsRequest>()?;
-            rpc_context
-                .get_multiple_compressed_accounts(payload)
+            let ApiAndIndexer { api, indexer } = rpc_context.as_ref();
+            conditionally_index_latest_blocks(indexer).await;
+            let payload = rpc_params.parse()?;
+            api.get_multiple_compressed_accounts(payload)
                 .await
                 .map_err(Into::into)
         },

--- a/src/ingester/indexer/mod.rs
+++ b/src/ingester/indexer/mod.rs
@@ -71,7 +71,7 @@ impl Indexer {
             index_block_batch_with_infinite_retries(self.db.as_ref(), blocks).await;
 
             if let Some(backfill) = &backfill {
-                if blocks_indexed <= (backfill.num_blocks_to_index as usize) {
+                if blocks_indexed <= backfill.num_blocks_to_index {
                     info!(
                         "Backfilled {} / {} blocks",
                         blocks_indexed, backfill.num_blocks_to_index
@@ -89,11 +89,10 @@ impl Indexer {
 }
 
 pub async fn continously_run_indexer(indexer: Arc<Mutex<Indexer>>) -> tokio::task::JoinHandle<()> {
-    let handle = tokio::spawn(async move {
+    tokio::spawn(async move {
         loop {
             indexer.deref().lock().await.index_latest_blocks(None).await;
             sleep(Duration::from_millis(20));
         }
-    });
-    handle
+    })
 }

--- a/src/ingester/indexer/mod.rs
+++ b/src/ingester/indexer/mod.rs
@@ -1,0 +1,99 @@
+use std::{ops::Deref, sync::Arc, thread::sleep, time::Duration};
+
+use log::info;
+use sea_orm::DatabaseConnection;
+use solana_client::nonblocking::rpc_client::RpcClient;
+use tokio::sync::Mutex;
+
+use crate::ingester::fetchers::poller::{fetch_current_slot_with_infinite_retry, Options};
+
+use super::{fetchers::poller::TransactionPoller, index_block_batch_with_infinite_retries};
+
+pub struct Indexer {
+    db: Arc<DatabaseConnection>,
+    poller: TransactionPoller,
+    max_batch_size: usize,
+}
+
+pub struct BackfillInfo {
+    pub num_blocks_to_index: usize,
+}
+
+impl Indexer {
+    pub async fn new(
+        db: Arc<DatabaseConnection>,
+        rpc_client: Arc<RpcClient>,
+        is_localnet: bool,
+        start_slot: Option<u64>,
+        max_batch_size: usize,
+    ) -> Self {
+        let current_slot = fetch_current_slot_with_infinite_retry(rpc_client.as_ref()).await;
+        let start_slot = match (start_slot, is_localnet) {
+            (Some(start_slot), _) => start_slot,
+            // Start indexing from the first slot for localnet.
+            (None, true) => 0,
+            (None, false) => current_slot,
+        };
+        let poller = TransactionPoller::new(rpc_client, Options { start_slot }).await;
+        let number_of_blocks_to_backfill = current_slot - start_slot;
+        info!(
+            "Backfilling historical blocks. Current number of blocks to backfill: {}",
+            number_of_blocks_to_backfill
+        );
+        if number_of_blocks_to_backfill > 10_000 && is_localnet {
+            info!("Backfilling a large number of blocks. This may take a while. Considering restarting local validator or specifying a start slot.");
+        }
+        let mut indexer = Self {
+            db,
+            poller,
+            max_batch_size,
+        };
+
+        indexer
+            .index_latest_blocks(Some(BackfillInfo {
+                num_blocks_to_index: number_of_blocks_to_backfill as usize,
+            }))
+            .await;
+
+        indexer
+    }
+
+    pub async fn index_latest_blocks(&mut self, backfill: Option<BackfillInfo>) {
+        let mut finished_initial_backfill = false;
+        let mut blocks_indexed = 0;
+
+        loop {
+            let blocks = self.poller.fetch_new_block_batch(self.max_batch_size).await;
+            if blocks.is_empty() {
+                break;
+            }
+            blocks_indexed += blocks.len();
+            index_block_batch_with_infinite_retries(self.db.as_ref(), blocks).await;
+
+            if let Some(backfill) = &backfill {
+                if blocks_indexed <= (backfill.num_blocks_to_index as usize) {
+                    info!(
+                        "Backfilled {} / {} blocks",
+                        blocks_indexed, backfill.num_blocks_to_index
+                    );
+                } else {
+                    if !finished_initial_backfill {
+                        info!("Backfilling new blocks since backfill started...");
+                        finished_initial_backfill = true;
+                    }
+                    info!("Backfilled {} blocks", blocks_indexed);
+                }
+            }
+        }
+    }
+}
+
+pub async fn continously_run_indexer(indexer: Arc<Mutex<Indexer>>) -> tokio::task::JoinHandle<()> {
+    let handle = tokio::spawn(async move {
+        loop {
+            indexer.deref().lock().await.index_latest_blocks(None).await;
+            sleep(Duration::from_millis(20));
+        }
+    });
+    handle
+}

--- a/src/ingester/mod.rs
+++ b/src/ingester/mod.rs
@@ -22,6 +22,7 @@ use self::typedefs::block_info::BlockMetadata;
 use crate::dao::generated::blocks;
 pub mod error;
 pub mod fetchers;
+pub mod indexer;
 pub mod parser;
 pub mod persist;
 pub mod typedefs;

--- a/src/ingester/persist/mod.rs
+++ b/src/ingester/persist/mod.rs
@@ -246,7 +246,7 @@ pub async fn persist_token_accounts(
                     delegate: Set(token_data.delegate.map(|d| d.to_bytes().to_vec())),
                     frozen: Set(token_data.state == AccountState::Frozen),
                     delegated_amount: Set(Decimal::from(token_data.delegated_amount)),
-                    is_native: Set(token_data.is_native.map(|n| Decimal::from(n))),
+                    is_native: Set(token_data.is_native.map(Decimal::from)),
                     spent: Set(false),
                     slot_updated: Set(slot_updated as i64),
                     ..Default::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
-use std::{fmt};
+use std::fmt;
 
 use clap::{Parser, ValueEnum};
 use jsonrpsee::server::ServerHandle;
 use log::{error, info};
 use photon_indexer::api::{self, api::PhotonApi};
-
 
 use photon_indexer::ingester::indexer::{continously_run_indexer, Indexer};
 use photon_indexer::migration::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,12 @@ use photon_indexer::ingester::fetchers::poller::{
     fetch_current_slot_with_infinite_retry, Options, TransactionPoller,
 };
 use photon_indexer::ingester::index_block_batch_with_infinite_retries;
+use photon_indexer::ingester::indexer::{continously_run_indexer, Indexer};
 use photon_indexer::migration::{
     sea_orm::{DatabaseBackend, DatabaseConnection, SqlxPostgresConnector, SqlxSqliteConnector},
     Migrator, MigratorTrait,
 };
+use sea_orm::Transaction;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use sqlx::{
     postgres::{PgConnectOptions, PgPoolOptions},
@@ -20,6 +22,7 @@ use sqlx::{
 };
 use std::env;
 use std::sync::Arc;
+use tokio::sync::Mutex;
 
 #[derive(Parser, Debug, Clone, ValueEnum)]
 enum LoggingFormat {
@@ -81,75 +84,16 @@ pub async fn setup_pg_pool(database_url: &str, max_connections: u32) -> PgPool {
         .unwrap()
 }
 
-async fn start_transaction_indexer(
-    db: Arc<DatabaseConnection>,
-    rpc_client: Arc<RpcClient>,
-    is_localnet: bool,
-    start_slot: Option<u64>,
-    max_batch_size: usize,
-) -> tokio::task::JoinHandle<()> {
-    // Spawn the task
-    let handle = tokio::spawn(async move {
-        let current_slot = fetch_current_slot_with_infinite_retry(rpc_client.as_ref()).await;
-        let start_slot = match (start_slot, is_localnet) {
-            (Some(start_slot), _) => start_slot,
-            // Start indexing from the first slot for localnet.
-            (None, true) => 0,
-            (None, false) => current_slot,
-        };
-        let mut poller = TransactionPoller::new(rpc_client, Options { start_slot }).await;
-        let number_of_blocks_to_backfill = current_slot - start_slot;
-        info!(
-            "Backfilling historical blocks. Current number of blocks to backfill: {}",
-            number_of_blocks_to_backfill
-        );
-        if number_of_blocks_to_backfill > 10_000 && is_localnet {
-            info!("Backfilling a large number of blocks. This may take a while. Considering restarting local validator or specifying a start slot.");
-        }
-        let mut finished_backfill = false;
-        let mut finished_initial_backfill = false;
-        let mut num_blocks_indexed_in_backfill = 0;
-
-        loop {
-            let blocks = poller.fetch_new_block_batch(max_batch_size).await;
-            if blocks.is_empty() {
-                sleep(Duration::from_millis(10));
-                if !finished_backfill {
-                    info!("Finished backfilling historical blocks...");
-                    info!("Streaming live blocks...");
-                }
-                finished_backfill = true;
-                continue;
-            }
-            num_blocks_indexed_in_backfill += blocks.len();
-            index_block_batch_with_infinite_retries(db.as_ref(), blocks).await;
-
-            if !finished_backfill {
-                if num_blocks_indexed_in_backfill <= (number_of_blocks_to_backfill as usize) {
-                    info!(
-                        "Backfilled {} / {} blocks",
-                        num_blocks_indexed_in_backfill, number_of_blocks_to_backfill
-                    );
-                } else {
-                    if !finished_initial_backfill {
-                        info!("Backfilling new blocks since backfill started...");
-                        finished_initial_backfill = true;
-                    }
-                    info!("Backfilled {} blocks", num_blocks_indexed_in_backfill);
-                }
-            }
-        }
-    });
-    handle
-}
-
 async fn start_api_server(
     db: Arc<DatabaseConnection>,
     rpc_client: Arc<RpcClient>,
+    indexer: Option<Arc<Mutex<Indexer>>>,
     api_port: u16,
 ) -> ServerHandle {
     let api = PhotonApi::new(db, rpc_client);
-    api::rpc_server::run_server(api, api_port).await.unwrap()
+    api::rpc_server::run_server(api, api_port, indexer)
+        .await
+        .unwrap()
 }
 
 fn setup_logging(logging_format: LoggingFormat) {
@@ -233,7 +177,7 @@ async fn main() {
             }
         }
     };
-    let indexer_handle = start_transaction_indexer(
+    let indexer = Indexer::new(
         db_conn.clone(),
         rpc_client.clone(),
         is_localnet,
@@ -241,9 +185,17 @@ async fn main() {
         max_concurrent_block_fetches,
     )
     .await;
+    let indexer = Arc::new(Mutex::new(indexer));
+    let indexer_handle = continously_run_indexer(indexer.clone()).await;
 
     info!("Starting API server with port {}...", args.port);
-    let api_handler = start_api_server(db_conn, rpc_client, args.port).await;
+    let api_handler = start_api_server(
+        db_conn,
+        rpc_client,
+        if is_localnet { Some(indexer) } else { None },
+        args.port,
+    )
+    .await;
     match tokio::signal::ctrl_c().await {
         Ok(()) => {
             info!("Shutting down indexer...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,17 @@
-use std::{fmt, thread::sleep, time::Duration};
+use std::{fmt};
 
 use clap::{Parser, ValueEnum};
 use jsonrpsee::server::ServerHandle;
 use log::{error, info};
 use photon_indexer::api::{self, api::PhotonApi};
-use photon_indexer::ingester::fetchers::poller::{
-    fetch_current_slot_with_infinite_retry, Options, TransactionPoller,
-};
-use photon_indexer::ingester::index_block_batch_with_infinite_retries;
+
+
 use photon_indexer::ingester::indexer::{continously_run_indexer, Indexer};
 use photon_indexer::migration::{
     sea_orm::{DatabaseBackend, DatabaseConnection, SqlxPostgresConnector, SqlxSqliteConnector},
     Migrator, MigratorTrait,
 };
-use sea_orm::Transaction;
+
 use solana_client::nonblocking::rpc_client::RpcClient;
 use sqlx::{
     postgres::{PgConnectOptions, PgPoolOptions},

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -108,12 +108,7 @@ fn request_schema(name: &str, params: Option<RefOr<Schema>>) -> RefOr<Schema> {
         "test-account",
         "An ID to identify the request.",
     );
-    builder = add_string_property(
-        builder,
-        "method",
-        &name,
-        "The name of the method to invoke.",
-    );
+    builder = add_string_property(builder, "method", name, "The name of the method to invoke.");
     builder = builder
         .required("jsonrpc")
         .required("id")


### PR DESCRIPTION
## Overview

-  Fix naming bug where we exposed the "getCompressedAccountsByOwner" endpoint as "getCompressedProgramAccounts". 
- Fixed a unsigned integer overflow bug that happened when the indexer got a slot smaller from the RPC that was smaller than the latest indexed bug
- Modified our localnet setup so that before every API request Photon indexes the latest Solana state data. This will provide a seamless experience to users -- every time they make an API request to Photon it will return the latest data. 
- Fixed warnings and cargo clippy issues
- Bumped the indexer version   

## Testing

-   Cargo test