### PR TITLE
Fix leaf index for proofs

### DIFF
--- a/src/ingester/parser/mod.rs
+++ b/src/ingester/parser/mod.rs
@@ -147,22 +147,26 @@ fn parse_public_transaction_event(
         state_update.out_accounts.push(enriched_account);
     }
 
-    state_update
-        .path_nodes
-        .extend(path_updates.into_iter().flat_map(|p| {
-            let tree_height = p.path.len();
-            p.path
-                .into_iter()
-                .enumerate()
-                .map(move |(i, node)| EnrichedPathNode {
-                    node: node.clone(),
-                    slot,
-                    tree: p.tree,
-                    seq: p.seq,
-                    level: i,
-                    tree_depth: tree_height,
-                })
-        }));
+    state_update.path_nodes.extend(
+        path_updates
+            .into_iter()
+            .zip(transaction_event.output_leaf_indices)
+            .flat_map(|(p, leaf_idx)| {
+                let tree_height = p.path.len();
+                p.path
+                    .into_iter()
+                    .enumerate()
+                    .map(move |(i, node)| EnrichedPathNode {
+                        node: node.clone(),
+                        slot,
+                        tree: p.tree,
+                        seq: p.seq,
+                        level: i,
+                        tree_depth: tree_height,
+                        leaf_index: if i == 0 { Some(leaf_idx) } else { None },
+                    })
+            }),
+    );
     Ok(state_update)
 }
 

--- a/src/ingester/parser/state_update.rs
+++ b/src/ingester/parser/state_update.rs
@@ -21,6 +21,7 @@ pub struct EnrichedPathNode {
     pub seq: u64,
     pub level: usize,
     pub tree_depth: usize,
+    pub leaf_index: Option<u32>
 }
 
 pub struct PathUpdate {

--- a/src/ingester/persist/mod.rs
+++ b/src/ingester/persist/mod.rs
@@ -284,14 +284,7 @@ async fn persist_path_nodes(
             level: Set(node.level as i64),
             node_idx: Set(node.node.index as i64),
             hash: Set(node.node.node.to_vec()),
-            leaf_idx: Set(if node.level == 0 {
-                Some(node_idx_to_leaf_idx(
-                    node.node.index as i64,
-                    node.tree_depth as u32,
-                ))
-            } else {
-                None
-            }),
+            leaf_idx: Set(node.leaf_index.map(|x| x as i64)),
             seq: Set(node.seq as i64),
             slot_updated: Set(node.slot as i64),
             ..Default::default()
@@ -316,8 +309,4 @@ async fn persist_path_nodes(
     txn.execute(query).await?;
 
     Ok(())
-}
-
-fn node_idx_to_leaf_idx(index: i64, tree_height: u32) -> i64 {
-    2i64.pow(tree_height) - index
 }

--- a/tests/integration_tests/mock_tests.rs
+++ b/tests/integration_tests/mock_tests.rs
@@ -560,6 +560,7 @@ async fn test_load_test(
             tree: tree.to_bytes(),
             seq: seq as u64,
             level: 0,
+            leaf_index: Some(seq as u32),
             tree_depth: 20,
         }
     }

--- a/tests/integration_tests/snapshots/integration_tests__e2e_tests__e2e_mint_and_transfer-bob-proofs.snap
+++ b/tests/integration_tests/snapshots/integration_tests__e2e_tests__e2e_mint_and_transfer-bob-proofs.snap
@@ -37,7 +37,7 @@ expression: proofs
         "11111111111111111111111111111111",
         "2RsHK3k6fNYWK2eei62pqgEwCuPw8aJbtd679ybqw2sJ"
       ],
-      "leafIndex": 67108862,
+      "leafIndex": 2,
       "hash": "oZ7nqSySeoVcM3ZF6KjSE3Q4wKj9NTWVA3dF4akhych",
       "merkleTree": "5bdFnXU47QjzGpzHfXnxcEi5WXyxzEAZzd1vrE39bf1W"
     }

--- a/tests/integration_tests/snapshots/integration_tests__e2e_tests__e2e_mint_and_transfer-charles-proofs.snap
+++ b/tests/integration_tests/snapshots/integration_tests__e2e_tests__e2e_mint_and_transfer-charles-proofs.snap
@@ -37,7 +37,7 @@ expression: proofs
         "11111111111111111111111111111111",
         "2RsHK3k6fNYWK2eei62pqgEwCuPw8aJbtd679ybqw2sJ"
       ],
-      "leafIndex": 67108863,
+      "leafIndex": 1,
       "hash": "3WCurN17webNLBJqAgCpjPjJbgWvAPnzXzxU2vEjS4YV",
       "merkleTree": "5bdFnXU47QjzGpzHfXnxcEi5WXyxzEAZzd1vrE39bf1W"
     }


### PR DESCRIPTION
## Overview

-   The leaf index computation was incorrect. Instead of deriving the leaf index from the node index, we are now just reading it from the onchain events. 

## Testing

-  Cargo test