### PR TITLE
Drop primary keys

### DIFF
--- a/src/api/method/utils.rs
+++ b/src/api/method/utils.rs
@@ -195,7 +195,6 @@ pub struct TokenAcccount {
     pub amount: Decimal,
     pub delegate: Option<SerializablePubkey>,
     pub is_native: bool,
-    pub close_authority: Option<SerializablePubkey>,
     pub frozen: bool,
     pub data: Base64String,
     pub data_hash: Option<Hash>,
@@ -247,7 +246,6 @@ pub struct GetCompressedTokenAccountsByDelegate {
 
 #[derive(FromQueryResult)]
 pub struct EnrichedTokenAccountModel {
-    pub id: i64,
     pub hash: Vec<u8>,
     pub address: Option<Vec<u8>>,
     pub owner: Vec<u8>,
@@ -257,7 +255,6 @@ pub struct EnrichedTokenAccountModel {
     pub frozen: bool,
     pub is_native: Option<Decimal>,
     pub delegated_amount: Decimal,
-    pub close_authority: Option<Vec<u8>>,
     pub spent: bool,
     pub slot_updated: i64,
     // Needed for generating proof
@@ -323,7 +320,6 @@ pub async fn fetch_token_accounts(
                 "Base account not found for token account".to_string(),
             ))?;
             Ok(EnrichedTokenAccountModel {
-                id: token_account.id,
                 hash: token_account.hash,
                 address: token_account.address,
                 owner: token_account.owner,
@@ -333,7 +329,6 @@ pub async fn fetch_token_accounts(
                 frozen: token_account.frozen,
                 is_native: token_account.is_native,
                 delegated_amount: token_account.delegated_amount,
-                close_authority: token_account.close_authority,
                 spent: token_account.spent,
                 slot_updated: token_account.slot_updated,
                 data: account.data,
@@ -387,10 +382,6 @@ pub fn parse_token_accounts_model(
             .map(SerializablePubkey::try_from)
             .transpose()?,
         is_native: token_account.is_native.is_some(),
-        close_authority: token_account
-            .close_authority
-            .map(SerializablePubkey::try_from)
-            .transpose()?,
         frozen: token_account.frozen,
         #[allow(deprecated)]
         data: Base64String(base64::encode(token_account.data)),

--- a/src/dao/generated/accounts.rs
+++ b/src/dao/generated/accounts.rs
@@ -5,8 +5,7 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "accounts")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i64,
+    #[sea_orm(primary_key, auto_increment = false)]
     pub hash: Vec<u8>,
     pub data: Vec<u8>,
     pub data_hash: Option<Vec<u8>>,

--- a/src/dao/generated/blocks.rs
+++ b/src/dao/generated/blocks.rs
@@ -5,8 +5,7 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "blocks")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i64,
+    #[sea_orm(primary_key, auto_increment = false)]
     pub slot: i64,
     pub parent_slot: i64,
     pub parent_blockhash: Vec<u8>,

--- a/src/dao/generated/state_trees.rs
+++ b/src/dao/generated/state_trees.rs
@@ -5,9 +5,9 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "state_trees")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i64,
+    #[sea_orm(primary_key, auto_increment = false)]
     pub tree: Vec<u8>,
+    #[sea_orm(primary_key, auto_increment = false)]
     pub node_idx: i64,
     pub leaf_idx: Option<i64>,
     pub level: i64,

--- a/src/dao/generated/token_accounts.rs
+++ b/src/dao/generated/token_accounts.rs
@@ -5,15 +5,13 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "token_accounts")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i64,
+    #[sea_orm(primary_key, auto_increment = false)]
     pub hash: Vec<u8>,
     pub address: Option<Vec<u8>>,
     pub owner: Vec<u8>,
     pub mint: Vec<u8>,
     pub delegate: Option<Vec<u8>>,
     pub frozen: bool,
-    pub close_authority: Option<Vec<u8>>,
     pub spent: bool,
     pub slot_updated: i64,
     pub created_at: Option<DateTime>,

--- a/src/ingester/persist/mod.rs
+++ b/src/ingester/persist/mod.rs
@@ -289,7 +289,6 @@ async fn persist_path_nodes(
             leaf_idx: Set(node.leaf_index.map(|x| x as i64)),
             seq: Set(node.seq as i64),
             slot_updated: Set(node.slot as i64),
-            ..Default::default()
         })
         .collect::<Vec<_>>();
 

--- a/src/migration/m20220101_000001_init.rs
+++ b/src/migration/m20220101_000001_init.rs
@@ -46,13 +46,6 @@ impl MigrationTrait for Migration {
                 Table::create()
                     .table(StateTrees::Table)
                     .if_not_exists()
-                    .col(
-                        ColumnDef::new(StateTrees::Id)
-                            .big_integer()
-                            .not_null()
-                            .auto_increment()
-                            .primary_key(),
-                    )
                     .col(ColumnDef::new(StateTrees::Tree).binary().not_null())
                     .col(ColumnDef::new(StateTrees::NodeIdx).big_integer().not_null())
                     .col(ColumnDef::new(StateTrees::LeafIdx).big_integer())
@@ -64,18 +57,12 @@ impl MigrationTrait for Migration {
                             .big_integer()
                             .not_null(),
                     )
-                    .to_owned(),
-            )
-            .await?;
-
-        manager
-            .create_index(
-                Index::create()
-                    .name("state_trees_tree_node_idx")
-                    .table(StateTrees::Table)
-                    .col(StateTrees::Tree)
-                    .col(StateTrees::NodeIdx)
-                    .unique()
+                    .primary_key(
+                        Index::create()
+                            .name("pk_state_trees")
+                            .col(StateTrees::Tree)
+                            .col(StateTrees::NodeIdx),
+                    )
                     .to_owned(),
             )
             .await?;
@@ -104,13 +91,6 @@ impl MigrationTrait for Migration {
                 Table::create()
                     .table(Accounts::Table)
                     .if_not_exists()
-                    .col(
-                        ColumnDef::new(Accounts::Id)
-                            .big_integer()
-                            .not_null()
-                            .auto_increment()
-                            .primary_key(),
-                    )
                     .col(ColumnDef::new(Accounts::Hash).binary().not_null())
                     .col(ColumnDef::new(Accounts::Data).binary().not_null())
                     .col(ColumnDef::new(Accounts::DataHash).binary())
@@ -131,17 +111,7 @@ impl MigrationTrait for Migration {
                             .timestamp()
                             .default(Expr::current_timestamp()),
                     )
-                    .to_owned(),
-            )
-            .await?;
-
-        manager
-            .create_index(
-                Index::create()
-                    .name("accounts_hash_idx")
-                    .table(Accounts::Table)
-                    .col(Accounts::Hash)
-                    .unique()
+                    .primary_key(Index::create().name("pk_accounts").col(Accounts::Hash))
                     .to_owned(),
             )
             .await?;
@@ -175,20 +145,12 @@ impl MigrationTrait for Migration {
                 Table::create()
                     .table(TokenAccounts::Table)
                     .if_not_exists()
-                    .col(
-                        ColumnDef::new(TokenAccounts::Id)
-                            .big_integer()
-                            .not_null()
-                            .auto_increment()
-                            .primary_key(),
-                    )
                     .col(ColumnDef::new(TokenAccounts::Hash).binary().not_null())
                     .col(ColumnDef::new(TokenAccounts::Address).binary())
                     .col(ColumnDef::new(TokenAccounts::Owner).binary().not_null())
                     .col(ColumnDef::new(TokenAccounts::Mint).binary().not_null())
                     .col(ColumnDef::new(TokenAccounts::Delegate).binary())
                     .col(ColumnDef::new(TokenAccounts::Frozen).boolean().not_null())
-                    .col(ColumnDef::new(TokenAccounts::CloseAuthority).binary())
                     .col(ColumnDef::new(TokenAccounts::Spent).boolean().not_null())
                     .foreign_key(
                         ForeignKey::create()
@@ -206,6 +168,11 @@ impl MigrationTrait for Migration {
                         ColumnDef::new(TokenAccounts::CreatedAt)
                             .timestamp()
                             .default(Expr::current_timestamp()),
+                    )
+                    .primary_key(
+                        Index::create()
+                            .name("pk_token_accounts")
+                            .col(TokenAccounts::Hash),
                     )
                     .to_owned(),
             )
@@ -264,17 +231,6 @@ impl MigrationTrait for Migration {
         manager
             .create_index(
                 Index::create()
-                    .name("token_accounts_hash_idx")
-                    .table(TokenAccounts::Table)
-                    .col(TokenAccounts::Hash)
-                    .unique()
-                    .to_owned(),
-            )
-            .await?;
-
-        manager
-            .create_index(
-                Index::create()
                     .name("token_accounts_address_idx")
                     .table(TokenAccounts::Table)
                     .col(TokenAccounts::Address)
@@ -315,30 +271,13 @@ impl MigrationTrait for Migration {
                 Table::create()
                     .table(Blocks::Table)
                     .if_not_exists()
-                    .col(
-                        ColumnDef::new(Blocks::Id)
-                            .big_integer()
-                            .not_null()
-                            .auto_increment()
-                            .primary_key(),
-                    )
                     .col(ColumnDef::new(Blocks::Slot).big_integer().not_null())
                     .col(ColumnDef::new(Blocks::ParentSlot).big_integer().not_null())
                     .col(ColumnDef::new(Blocks::ParentBlockhash).binary().not_null())
                     .col(ColumnDef::new(Blocks::Blockhash).binary().not_null())
                     .col(ColumnDef::new(Blocks::BlockHeight).big_integer().not_null())
                     .col(ColumnDef::new(Blocks::BlockTime).big_integer().not_null())
-                    .to_owned(),
-            )
-            .await?;
-
-        manager
-            .create_index(
-                Index::create()
-                    .name("blocks_slot_idx")
-                    .table(Blocks::Table)
-                    .col(Blocks::Slot)
-                    .unique()
+                    .primary_key(Index::create().name("pk_blocks").col(Blocks::Slot))
                     .to_owned(),
             )
             .await?;

--- a/src/migration/model/table.rs
+++ b/src/migration/model/table.rs
@@ -3,7 +3,6 @@ use sea_orm_migration::prelude::*;
 #[derive(Copy, Clone, Iden)]
 pub enum StateTrees {
     Table,
-    Id,
     Tree,
     NodeIdx,
     LeafIdx,
@@ -16,7 +15,6 @@ pub enum StateTrees {
 #[derive(Copy, Clone, Iden)]
 pub enum Accounts {
     Table,
-    Id,
     Hash,
     Address,
     Data,
@@ -34,14 +32,12 @@ pub enum Accounts {
 #[derive(Copy, Clone, Iden)]
 pub enum TokenAccounts {
     Table,
-    Id,
     Hash,
     Address,
     Owner,
     Mint,
     Delegate,
     Frozen,
-    CloseAuthority,
     // Duplicate to Spent in accounts. Added to simplify the handling of concurrent insertions and deletions
     // of token accounts.
     Spent,
@@ -52,7 +48,6 @@ pub enum TokenAccounts {
 #[derive(Copy, Clone, Iden)]
 pub enum Blocks {
     Table,
-    Id,
     Slot,
     ParentSlot,
     Blockhash,

--- a/tests/integration_tests/snapshots/integration_tests__e2e_tests__e2e_mint_and_transfer-bob-accounts.snap
+++ b/tests/integration_tests/snapshots/integration_tests__e2e_tests__e2e_mint_and_transfer-bob-accounts.snap
@@ -16,7 +16,6 @@ expression: accounts
         "amount": "300",
         "delegate": null,
         "isNative": false,
-        "closeAuthority": null,
         "frozen": false,
         "data": "Uaavg4642BlU0qzdHNvTw5bjJPaj3sslz6Mzu1JUXgRrecV+aglSOSgsBIGOlhEvPwOkABupelZMI4UqPx6l/CwBAAAAAAAAAAEAAAAAAAAAAAA=",
         "dataHash": "2oxvZ6Cr89GyYziwQeYhjwyCodJw4D8pr8aCd6AmymoT",

--- a/tests/integration_tests/snapshots/integration_tests__e2e_tests__e2e_mint_and_transfer-charles-accounts.snap
+++ b/tests/integration_tests/snapshots/integration_tests__e2e_tests__e2e_mint_and_transfer-charles-accounts.snap
@@ -16,7 +16,6 @@ expression: accounts
         "amount": "700",
         "delegate": null,
         "isNative": false,
-        "closeAuthority": null,
         "frozen": false,
         "data": "Uaavg4642BlU0qzdHNvTw5bjJPaj3sslz6Mzu1JUXgTa29GEotUm8evdXAb9rZNZsih1m01/edZmifolSq2FRrwCAAAAAAAAAAEAAAAAAAAAAAA=",
         "dataHash": "37iQQorCPpRDmQ7hddqrdFPFhzh5KnQHNs1CnVUVzfz9",


### PR DESCRIPTION
## Overview

I don't see a benefit in having them. They add the code slower and force you to use Default::default() when adding columns.
