### PR TITLE
Re-add root node to proof

### DIFF
--- a/src/api/method/get_multiple_compressed_account_proofs.rs
+++ b/src/api/method/get_multiple_compressed_account_proofs.rs
@@ -173,6 +173,7 @@ pub fn get_proof_path(index: i64) -> Vec<i64> {
         }
         idx >>= 1
     }
+    indexes.push(1);
     indexes
 }
 

--- a/tests/integration_tests/e2e_tests.rs
+++ b/tests/integration_tests/e2e_tests.rs
@@ -1,7 +1,7 @@
 use function_name::named;
 use itertools::Itertools;
 use photon_indexer::api::method::get_compressed_accounts_by_owner::GetCompressedAccountsByOwnerRequest;
-use photon_indexer::api::method::get_transaction::{get_transaction_helper};
+use photon_indexer::api::method::get_transaction::get_transaction_helper;
 use photon_indexer::common::typedefs::serializable_pubkey::SerializablePubkey;
 use photon_indexer::ingester::index_block;
 

--- a/tests/integration_tests/snapshots/integration_tests__e2e_tests__e2e_mint_and_transfer-bob-proofs.snap
+++ b/tests/integration_tests/snapshots/integration_tests__e2e_tests__e2e_mint_and_transfer-bob-proofs.snap
@@ -34,7 +34,8 @@ expression: proofs
         "2fomPS2xUPwXxVF8hx5YtMpBHmQKSZKushUiWYsy9Eqx",
         "3Pi3nRu4fWpnW5rYDAoraX1Q2xDCRQ24Dq8TEY7gaSBn",
         "3dbMMyehykAriNZ8FMJgPc1N6YSzm9ZfV2HcW9sbaXzP",
-        "4EE5KQnQ6Tvo78gGhTu8serpJV4srbRhYZ3rdvCiRa5e"
+        "4EE5KQnQ6Tvo78gGhTu8serpJV4srbRhYZ3rdvCiRa5e",
+        "2RsHK3k6fNYWK2eei62pqgEwCuPw8aJbtd679ybqw2sJ"
       ],
       "leafIndex": 2,
       "hash": "oZ7nqSySeoVcM3ZF6KjSE3Q4wKj9NTWVA3dF4akhych",

--- a/tests/integration_tests/snapshots/integration_tests__e2e_tests__e2e_mint_and_transfer-charles-proofs.snap
+++ b/tests/integration_tests/snapshots/integration_tests__e2e_tests__e2e_mint_and_transfer-charles-proofs.snap
@@ -34,7 +34,8 @@ expression: proofs
         "2fomPS2xUPwXxVF8hx5YtMpBHmQKSZKushUiWYsy9Eqx",
         "3Pi3nRu4fWpnW5rYDAoraX1Q2xDCRQ24Dq8TEY7gaSBn",
         "3dbMMyehykAriNZ8FMJgPc1N6YSzm9ZfV2HcW9sbaXzP",
-        "4EE5KQnQ6Tvo78gGhTu8serpJV4srbRhYZ3rdvCiRa5e"
+        "4EE5KQnQ6Tvo78gGhTu8serpJV4srbRhYZ3rdvCiRa5e",
+        "2RsHK3k6fNYWK2eei62pqgEwCuPw8aJbtd679ybqw2sJ"
       ],
       "leafIndex": 1,
       "hash": "3WCurN17webNLBJqAgCpjPjJbgWvAPnzXzxU2vEjS4YV",


### PR DESCRIPTION
## Overview

- Re-add root node to proof per Light's request so that they don't need to compute hashes.

## Testing

-  Cargo test 