### PR TITLE
Store sqllite db in temp file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "photon-indexer"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anchor-lang",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "photon-indexer"
 publish = true
 readme = "README.md"
 repository = "https://github.com/helius-labs/photon"
-version = "0.16.0"
+version = "0.17.0"
 
 [[bin]]
 name = "photon"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ photon
 # Against devnet
 photon --rpc-url=https://api.devnet.solana.com
 
-# Using your local Postgres database instead of the default in in-memory SQLite db
+# Using your local Postgres database instead of the default temporary SQL database
 photon --db-url=postgres://postgres@localhost/postgres
 
 # Specifying a start slot. Defaults to 0 for localnet and current for devnet/mainnet


### PR DESCRIPTION
## Overview

-   For some reason, the in-memory database is being dropped after 20 minutes or so. This is a pretty hard to debug issue because of how long it takes to reproduce. So I decided to just use temporary file in a temporary directory instead to fix the issue. 

## Testing

-   Ran Photon locally. 