### PR TITLE
Optimize writes per second from 250 to 10k

### DIFF
--- a/src/ingester/persist/mod.rs
+++ b/src/ingester/persist/mod.rs
@@ -33,9 +33,8 @@ pub mod persisted_state_tree;
 
 const COMPRESSED_TOKEN_PROGRAM: Pubkey = pubkey!("HXVfQ44ATEi9WBKLSCCwM54KokdkzqXci9xCQ7ST9SYN");
 const TREE_HEIGHT: u32 = 27;
-// To avoid exceeding the 25k total parameter limit, we set the insert limit to 1k (as we have fewer
-// than 10 columns per table).
-pub const MAX_SQL_INSERTS: usize = 1000;
+// To avoid exceeding the 64k total parameter limit
+pub const MAX_SQL_INSERTS: usize = 5000;
 
 pub async fn persist_state_update(
     txn: &DatabaseTransaction,
@@ -342,6 +341,7 @@ async fn append_output_accounts(
     }
 
     if !out_accounts.is_empty() {
+        let start_time = std::time::Instant::now();
         let query = accounts::Entity::insert_many(account_models)
             .on_conflict(
                 OnConflict::column(accounts::Column::Hash)
@@ -356,6 +356,7 @@ async fn append_output_accounts(
             ModificationType::Append,
         )
         .await?;
+        println!("Time to insert accounts: {:?}", start_time.elapsed());
 
         if !token_accounts.is_empty() {
             debug!("Persisting {} token accounts...", token_accounts.len());

--- a/src/ingester/persist/mod.rs
+++ b/src/ingester/persist/mod.rs
@@ -341,7 +341,6 @@ async fn append_output_accounts(
     }
 
     if !out_accounts.is_empty() {
-        let start_time = std::time::Instant::now();
         let query = accounts::Entity::insert_many(account_models)
             .on_conflict(
                 OnConflict::column(accounts::Column::Hash)
@@ -356,7 +355,6 @@ async fn append_output_accounts(
             ModificationType::Append,
         )
         .await?;
-        println!("Time to insert accounts: {:?}", start_time.elapsed());
 
         if !token_accounts.is_empty() {
             debug!("Persisting {} token accounts...", token_accounts.len());

--- a/src/ingester/persist/persisted_state_tree.rs
+++ b/src/ingester/persist/persisted_state_tree.rs
@@ -136,7 +136,11 @@ pub async fn persist_leaf_nodes(
                 .map(move |(i, &idx)| (leaf_node.tree.to_bytes_vec(), idx, i))
                 .collect::<Vec<(Vec<u8>, i64, usize)>>()
         })
-        .sorted() // Need to sort elements before dedup
+        .sorted_by(|a, b| {
+            // Need to sort elements before dedup
+            a.0.cmp(&b.0) // Sort by tree
+                .then_with(|| a.1.cmp(&b.1)) // Then by node index
+        }) // Need to sort elements before dedup
         .dedup()
         .collect::<Vec<(Vec<u8>, i64, usize)>>();
 
@@ -421,7 +425,11 @@ where
                 .map(move |&idx| (tree.clone(), idx))
                 .collect::<Vec<(Vec<u8>, i64)>>()
         })
-        .sorted() // Need to sort elements before dedup
+        .sorted_by(|a, b| {
+            // Need to sort elements before dedup
+            a.0.cmp(&b.0) // Sort by tree
+                .then_with(|| a.1.cmp(&b.1)) // Then by node index
+        })
         .dedup()
         .collect::<Vec<(Vec<u8>, i64)>>();
 

--- a/tests/integration_tests/open_api_tests.rs
+++ b/tests/integration_tests/open_api_tests.rs
@@ -1,6 +1,6 @@
-// use photon_indexer::openapi::update_docs;
+use photon_indexer::openapi::update_docs;
 
-// #[test]
-// pub fn test_documentation_generation() {
-//     update_docs(true);
-// }
+#[test]
+pub fn test_documentation_generation() {
+    update_docs(true);
+}

--- a/tests/integration_tests/open_api_tests.rs
+++ b/tests/integration_tests/open_api_tests.rs
@@ -1,6 +1,6 @@
-use photon_indexer::openapi::update_docs;
+// use photon_indexer::openapi::update_docs;
 
-#[test]
-pub fn test_documentation_generation() {
-    update_docs(true);
-}
+// #[test]
+// pub fn test_documentation_generation() {
+//     update_docs(true);
+// }


### PR DESCRIPTION
## Overview
- Fixed a bug where we failed to deduplicate some tree nodes -- dedup() only works if input is sorted apparently 
- Optimized get_proof_nodes query by using CTE of leaf node values instead of the IN CLAUSE. Not sure exactly why it worked but it reduced query times about 40x.
- Reduce code duplication in constructing the state trees 

## Testing

-   Cargo test 