### PR TITLE
Fix migration file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.81-slim-bullseye
+FROM rust:1.87-slim-bullseye
 RUN apt update && apt install -y build-essential pkg-config libssl-dev
 
 # Copy the project files

--- a/src/migration/migrations/standard/m20250206_000007_init.rs
+++ b/src/migration/migrations/standard/m20250206_000007_init.rs
@@ -110,7 +110,7 @@ impl MigrationTrait for Migration {
                 .alter_table(
                     Table::alter()
                         .table(Accounts::Table)
-                        .add_column(ColumnDef::new(Accounts::TreeType).integer().null())
+                        .add_column_if_not_exists(ColumnDef::new(Accounts::TreeType).integer().null())
                         .to_owned(),
                 )
                 .await?;
@@ -119,7 +119,7 @@ impl MigrationTrait for Migration {
                 .alter_table(
                     Table::alter()
                         .table(Accounts::Table)
-                        .add_column(
+                        .add_column_if_not_exists(
                             ColumnDef::new(Accounts::NullifiedInTree)
                                 .boolean()
                                 .not_null()
@@ -133,7 +133,7 @@ impl MigrationTrait for Migration {
                 .alter_table(
                     Table::alter()
                         .table(Accounts::Table)
-                        .add_column(
+                        .add_column_if_not_exists(
                             ColumnDef::new(Accounts::NullifierQueueIndex)
                                 .big_integer()
                                 .null(),
@@ -146,7 +146,7 @@ impl MigrationTrait for Migration {
                 .alter_table(
                     Table::alter()
                         .table(Accounts::Table)
-                        .add_column(
+                        .add_column_if_not_exists(
                             ColumnDef::new(Accounts::InOutputQueue)
                                 .boolean()
                                 .not_null()
@@ -160,7 +160,7 @@ impl MigrationTrait for Migration {
                 .alter_table(
                     Table::alter()
                         .table(Accounts::Table)
-                        .add_column(ColumnDef::new(Accounts::Queue).binary().not_null())
+                        .add_column_if_not_exists(ColumnDef::new(Accounts::Queue).binary().not_null())
                         .to_owned(),
                 )
                 .await?;
@@ -169,7 +169,7 @@ impl MigrationTrait for Migration {
                 .alter_table(
                     Table::alter()
                         .table(Accounts::Table)
-                        .add_column(ColumnDef::new(Accounts::Nullifier).binary().null())
+                        .add_column_if_not_exists(ColumnDef::new(Accounts::Nullifier).binary().null())
                         .to_owned(),
                 )
                 .await?;
@@ -178,7 +178,7 @@ impl MigrationTrait for Migration {
                 .alter_table(
                     Table::alter()
                         .table(Accounts::Table)
-                        .add_column(ColumnDef::new(Accounts::TxHash).binary().null())
+                        .add_column_if_not_exists(ColumnDef::new(Accounts::TxHash).binary().null())
                         .to_owned(),
                 )
                 .await?;


### PR DESCRIPTION
## Overview

-   For some reason, I think this migration failed a long time ago when I tried to apply it to devnet. Now it's failing in an earlier stage because I am trying to create columns that already exist. So, changing migration to only create columns if they don't exist. I'll rerun the migration afterwards and figure out the root cause of why this migration failed originally.