### PR TITLE
fix: proof gen for empty v1 address trees

### DIFF
--- a/src/ingester/persist/indexed_merkle_tree/proof.rs
+++ b/src/ingester/persist/indexed_merkle_tree/proof.rs
@@ -4,15 +4,17 @@ use crate::common::typedefs::hash::Hash;
 use crate::common::typedefs::serializable_pubkey::SerializablePubkey;
 use crate::dao::generated::indexed_trees;
 use crate::ingester::error::IngesterError;
+use crate::ingester::parser::tree_info::TreeInfo;
 use crate::ingester::persist::indexed_merkle_tree::{
-    compute_hash_by_tree_height, compute_range_node_hash_v1, get_zeroeth_exclusion_range,
-    get_zeroeth_exclusion_range_v1,
+    compute_hash_by_tree_height, compute_range_node_hash_v1, get_top_element,
+    get_zeroeth_exclusion_range, get_zeroeth_exclusion_range_v1,
 };
 use crate::ingester::persist::persisted_state_tree::ZERO_BYTES;
 use crate::ingester::persist::{
     compute_parent_hash, get_multiple_compressed_leaf_proofs_from_full_leaf_info, LeafNode,
     MerkleProofWithContext, TREE_HEIGHT_V1,
 };
+use light_compressed_account::TreeType;
 use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseTransaction, Statement, TransactionTrait};
 use std::collections::BTreeMap;
 
@@ -90,11 +92,17 @@ fn proof_for_empty_tree(
     tree: Vec<u8>,
     tree_height: u32,
 ) -> Result<(indexed_trees::Model, MerkleProofWithContext), PhotonApiError> {
-    let root_seq = if tree_height == TREE_HEIGHT_V1 + 1 {
-        2
-    } else {
-        0
+    let tree_bytes: [u8; 32] = tree
+        .as_slice()
+        .try_into()
+        .map_err(|_| PhotonApiError::UnexpectedError("Invalid tree pubkey length".to_string()))?;
+    let tree_type = TreeInfo::get_tree_type_from_bytes(&tree_bytes);
+
+    let root_seq = match tree_type {
+        TreeType::AddressV1 => 3,
+        _ => 0,
     };
+
     proof_for_empty_tree_with_seq(tree, tree_height, root_seq)
 }
 
@@ -103,6 +111,24 @@ fn proof_for_empty_tree_with_seq(
     tree_height: u32,
     root_seq: u64,
 ) -> Result<(indexed_trees::Model, MerkleProofWithContext), PhotonApiError> {
+    let mut proof: Vec<Hash> = vec![];
+
+    if tree_height == TREE_HEIGHT_V1 + 1 {
+        let top_element = get_top_element(tree.clone());
+        let top_element_hash = compute_hash_by_tree_height(&top_element, tree_height)?;
+        proof.push(top_element_hash);
+
+        for i in 1..(tree_height - 1) {
+            let hash = Hash::from(ZERO_BYTES[i as usize]);
+            proof.push(hash);
+        }
+    } else {
+        for i in 0..(tree_height - 1) {
+            let hash = Hash::from(ZERO_BYTES[i as usize]);
+            proof.push(hash);
+        }
+    }
+
     let zeroeth_element = if tree_height == TREE_HEIGHT_V1 + 1 {
         get_zeroeth_exclusion_range_v1(tree.clone())
     } else {
@@ -110,34 +136,25 @@ fn proof_for_empty_tree_with_seq(
     };
     let zeroeth_element_hash = compute_hash_by_tree_height(&zeroeth_element, tree_height)?;
 
-    let mut proof: Vec<Hash> = vec![];
-    for i in 0..(tree_height - 1) {
-        let hash = Hash::try_from(ZERO_BYTES[i as usize]).map_err(|e| {
-            PhotonApiError::UnexpectedError(format!("Failed to convert hash: {}", e))
-        })?;
-        proof.push(hash);
-    }
-
     let mut root = zeroeth_element_hash.clone().to_vec();
 
     for elem in proof.iter() {
-        root = compute_parent_hash(root, elem.to_vec()).map_err(|e| {
-            PhotonApiError::UnexpectedError(format!("Failed to compute hash: {}", e))
-        })?;
+        root = compute_parent_hash(root, elem.to_vec())
+            .map_err(|e| PhotonApiError::UnexpectedError(format!("Failed to compute hash: {e}")))?;
     }
 
     let merkle_proof = MerkleProofWithContext {
         proof,
-        root: Hash::try_from(root).map_err(|e| {
-            PhotonApiError::UnexpectedError(format!("Failed to convert hash: {}", e))
-        })?,
+        root: Hash::try_from(root.clone())
+            .map_err(|e| PhotonApiError::UnexpectedError(format!("Failed to convert hash: {e}")))?,
         leaf_index: 0,
         hash: zeroeth_element_hash,
         merkle_tree: SerializablePubkey::try_from(tree.clone()).map_err(|e| {
-            PhotonApiError::UnexpectedError(format!("Failed to serialize pubkey: {}", e))
+            PhotonApiError::UnexpectedError(format!("Failed to serialize pubkey: {e}"))
         })?,
         root_seq,
     };
+
     merkle_proof.validate()?;
     Ok((zeroeth_element, merkle_proof))
 }
@@ -151,10 +168,7 @@ pub async fn get_exclusion_range_with_proof_v1(
     let btree = query_next_smallest_elements(txn, vec![value.clone()], tree.clone())
         .await
         .map_err(|e| {
-            PhotonApiError::UnexpectedError(format!(
-                "Failed to query next smallest elements: {}",
-                e
-            ))
+            PhotonApiError::UnexpectedError(format!("Failed to query next smallest elements: {e}"))
         })?;
 
     if btree.is_empty() {
@@ -165,11 +179,11 @@ pub async fn get_exclusion_range_with_proof_v1(
         "No range proof found".to_string(),
     ))?;
     let hash = compute_range_node_hash_v1(range_node)
-        .map_err(|e| PhotonApiError::UnexpectedError(format!("Failed to compute hash: {}", e)))?;
+        .map_err(|e| PhotonApiError::UnexpectedError(format!("Failed to compute hash: {e}")))?;
 
     let leaf_node = LeafNode {
         tree: SerializablePubkey::try_from(range_node.tree.clone()).map_err(|e| {
-            PhotonApiError::UnexpectedError(format!("Failed to serialize pubkey: {}", e))
+            PhotonApiError::UnexpectedError(format!("Failed to serialize pubkey: {e}"))
         })?,
         leaf_index: range_node.leaf_index as u32,
         hash,
@@ -184,22 +198,19 @@ pub async fn get_exclusion_range_with_proof_v1(
                 let tree_pubkey = match SerializablePubkey::try_from(range_node.tree.clone()) {
                     Ok(pubkey) => pubkey,
                     Err(e) => {
-                        log::error!("Failed to serialize tree pubkey: {}", e);
+                        log::error!("Failed to serialize tree pubkey: {e}");
                         return proof_error;
                     }
                 };
                 let value_pubkey = match SerializablePubkey::try_from(range_node.value.clone()) {
                     Ok(pubkey) => pubkey,
                     Err(e) => {
-                        log::error!("Failed to serialize value pubkey: {}", e);
+                        log::error!("Failed to serialize value pubkey: {e}");
                         return proof_error;
                     }
                 };
                 log::error!(
-                    "Failed to get multiple compressed leaf proofs for {:?} for value {:?}: {}",
-                    tree_pubkey,
-                    value_pubkey,
-                    proof_error
+                    "Failed to get multiple compressed leaf proofs for {tree_pubkey:?} for value {value_pubkey:?}: {proof_error}"
                 );
                 proof_error
             })?;
@@ -241,7 +252,7 @@ where
                 ))
                 .await
                 .map_err(|e| {
-                    IngesterError::DatabaseError(format!("Failed to execute indexed query: {}", e))
+                    IngesterError::DatabaseError(format!("Failed to execute indexed query: {e}"))
                 })?
         }
         DatabaseBackend::Sqlite => {
@@ -261,8 +272,7 @@ where
                     .await
                     .map_err(|e| {
                         IngesterError::DatabaseError(format!(
-                            "Failed to execute indexed query: {}",
-                            e
+                            "Failed to execute indexed query: {e}"
                         ))
                     })?;
                 response.extend(result);

--- a/tests/integration_tests/snapshots/integration_tests__mock_tests__get_multiple_new_address_proofs.snap
+++ b/tests/integration_tests/snapshots/integration_tests__mock_tests__get_multiple_new_address_proofs.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/integration_tests/mock_tests.rs
-assertion_line: 1085
+assertion_line: 1086
 expression: proof
 ---
 {
@@ -9,13 +9,13 @@ expression: proof
   },
   "value": [
     {
-      "root": "35jQgsScN7DtyLQL6cMFfmUML23t1AJ9RzNe5wGeXsuq",
+      "root": "3FrGzyXtjqjnukHDS2M5oyVj8tMVcHSahcHpWBGR5MHY",
       "address": "Fi6AXBGuGs7DRXP428hwhJJfTpJ4BVZD8DiUcX1cj35W",
       "lowerRangeAddress": "11111111111111111111111111111111",
       "higherRangeAddress": "14uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofL",
       "nextIndex": 1,
       "proof": [
-        "11111111111111111111111111111111",
+        "34cMT7MjFrs8hLp2zHMrPJHKkUxBDBwBTNck77wLjjcY",
         "3CFKteYSRSkp9EGFPzibgzCPtNuJ5HeZ31fAsBpgcHwZ",
         "274k4KPY5VhmU5pCwwJzyHaY4AH4m7SjnZnyj44UitJc",
         "2gQksfK543Jw196amPxXWceFzNTfRHiqb7x2edvupftT",
@@ -43,17 +43,17 @@ expression: proof
         "4EE5KQnQ6Tvo78gGhTu8serpJV4srbRhYZ3rdvCiRa5e"
       ],
       "merkleTree": "amt1Ayt45jfbdw5YSo7iz6WZxUmnZsQTYXy82hVwyC2",
-      "rootSeq": 2,
+      "rootSeq": 3,
       "lowElementLeafIndex": 0
     },
     {
-      "root": "35jQgsScN7DtyLQL6cMFfmUML23t1AJ9RzNe5wGeXsuq",
+      "root": "3FrGzyXtjqjnukHDS2M5oyVj8tMVcHSahcHpWBGR5MHY",
       "address": "sH8ux4csv8wxiRejuHjpTCkrfGgeNtg6Y55AJJ9GJSd",
       "lowerRangeAddress": "11111111111111111111111111111111",
       "higherRangeAddress": "14uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofL",
       "nextIndex": 1,
       "proof": [
-        "11111111111111111111111111111111",
+        "34cMT7MjFrs8hLp2zHMrPJHKkUxBDBwBTNck77wLjjcY",
         "3CFKteYSRSkp9EGFPzibgzCPtNuJ5HeZ31fAsBpgcHwZ",
         "274k4KPY5VhmU5pCwwJzyHaY4AH4m7SjnZnyj44UitJc",
         "2gQksfK543Jw196amPxXWceFzNTfRHiqb7x2edvupftT",
@@ -81,7 +81,7 @@ expression: proof
         "4EE5KQnQ6Tvo78gGhTu8serpJV4srbRhYZ3rdvCiRa5e"
       ],
       "merkleTree": "amt1Ayt45jfbdw5YSo7iz6WZxUmnZsQTYXy82hVwyC2",
-      "rootSeq": 2,
+      "rootSeq": 3,
       "lowElementLeafIndex": 0
     }
   ]

--- a/tests/integration_tests/snapshots/integration_tests__mock_tests__get_multiple_new_address_proofs_interop-validity-proof-v2.snap
+++ b/tests/integration_tests/snapshots/integration_tests__mock_tests__get_multiple_new_address_proofs_interop-validity-proof-v2.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/integration_tests/mock_tests.rs
-assertion_line: 1175
+assertion_line: 1176
 expression: validity_proof_v2
 ---
 {
@@ -14,8 +14,8 @@ expression: validity_proof_v2
     "addresses": [
       {
         "address": "12nCKqGG85jHxbTeA8i2Z7D4vnNUUrQ4r5e8dv2o16X",
-        "root": "35jQgsScN7DtyLQL6cMFfmUML23t1AJ9RzNe5wGeXsuq",
-        "rootIndex": 2,
+        "root": "3FrGzyXtjqjnukHDS2M5oyVj8tMVcHSahcHpWBGR5MHY",
+        "rootIndex": 3,
         "merkleContext": {
           "treeType": 2,
           "tree": "amt1Ayt45jfbdw5YSo7iz6WZxUmnZsQTYXy82hVwyC2",

--- a/tests/integration_tests/snapshots/integration_tests__mock_tests__get_multiple_new_address_proofs_interop-validity-proof.snap
+++ b/tests/integration_tests/snapshots/integration_tests__mock_tests__get_multiple_new_address_proofs_interop-validity-proof.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/integration_tests/mock_tests.rs
-assertion_line: 1143
+assertion_line: 1144
 expression: validity_proof
 ---
 {
@@ -11,10 +11,10 @@ expression: validity_proof
       "c": []
     },
     "roots": [
-      "35jQgsScN7DtyLQL6cMFfmUML23t1AJ9RzNe5wGeXsuq"
+      "3FrGzyXtjqjnukHDS2M5oyVj8tMVcHSahcHpWBGR5MHY"
     ],
     "rootIndices": [
-      2
+      3
     ],
     "leafIndices": [
       0

--- a/tests/integration_tests/snapshots/integration_tests__mock_tests__get_multiple_new_address_proofs_interop.snap
+++ b/tests/integration_tests/snapshots/integration_tests__mock_tests__get_multiple_new_address_proofs_interop.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/integration_tests/mock_tests.rs
-assertion_line: 1128
+assertion_line: 1129
 expression: proof
 ---
 {
@@ -9,13 +9,13 @@ expression: proof
   },
   "value": [
     {
-      "root": "35jQgsScN7DtyLQL6cMFfmUML23t1AJ9RzNe5wGeXsuq",
+      "root": "3FrGzyXtjqjnukHDS2M5oyVj8tMVcHSahcHpWBGR5MHY",
       "address": "12nCKqGG85jHxbTeA8i2Z7D4vnNUUrQ4r5e8dv2o16X",
       "lowerRangeAddress": "11111111111111111111111111111111",
       "higherRangeAddress": "14uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofL",
       "nextIndex": 1,
       "proof": [
-        "11111111111111111111111111111111",
+        "34cMT7MjFrs8hLp2zHMrPJHKkUxBDBwBTNck77wLjjcY",
         "3CFKteYSRSkp9EGFPzibgzCPtNuJ5HeZ31fAsBpgcHwZ",
         "274k4KPY5VhmU5pCwwJzyHaY4AH4m7SjnZnyj44UitJc",
         "2gQksfK543Jw196amPxXWceFzNTfRHiqb7x2edvupftT",
@@ -43,7 +43,7 @@ expression: proof
         "4EE5KQnQ6Tvo78gGhTu8serpJV4srbRhYZ3rdvCiRa5e"
       ],
       "merkleTree": "amt1Ayt45jfbdw5YSo7iz6WZxUmnZsQTYXy82hVwyC2",
-      "rootSeq": 2,
+      "rootSeq": 3,
       "lowElementLeafIndex": 0
     }
   ]


### PR DESCRIPTION
This PR fixes proof generation for empty v1 address trees.
In v1, the address tree reserves the first two positions for the zero element and the top element, which was previously not handled correctly.
The generated snapshots now match[ the old snapshots from before the v2 refactoring](https://github.com/helius-labs/photon/blob/a24b5213cb6e3185ece0109b1df775ddac359e92/tests/integration_tests/snapshots/integration_tests__mock_tests__get_multiple_new_address_proofs.snap). 