### PR TITLE
feat: skip unknown trees

### DIFF
--- a/src/ingester/parser/mod.rs
+++ b/src/ingester/parser/mod.rs
@@ -37,6 +37,8 @@ const SYSTEM_PROGRAM: Pubkey = pubkey!("11111111111111111111111111111111");
 const NOOP_PROGRAM_ID: Pubkey = pubkey!("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
 const VOTE_PROGRAM_ID: Pubkey = pubkey!("Vote111111111111111111111111111111111111111");
 
+const SKIP_UNKNOWN_TREES: bool = true;
+
 pub fn parse_transaction(tx: &TransactionInfo, slot: u64) -> Result<StateUpdate, IngesterError> {
     let mut state_updates = Vec::new();
     let mut is_compression_transaction = false;

--- a/src/ingester/parser/tree_info.rs
+++ b/src/ingester/parser/tree_info.rs
@@ -82,6 +82,10 @@ lazy_static! {
                 pubkey!("nfqB3FAiiB1p3ksiWHB48LzSycpaJZ5RTp5C8RtNyUH"),
             ),
             (
+                pubkey!("smtB1XUpt3c7j7udurMdxmAGib7RzCyBXu95fAZoHyT"),
+                pubkey!("nfqByCmDtLy7pkKpazApswN5H3Y4RSgCVq7NpecLHza"),
+            ),
+            (
                 pubkey!("smtCEeVJsWyeeawgn5cQR5iK7dsJwnxJq7QwdQUepx8"),
                 pubkey!("nfqC5pX1HzaTgUApL2DTp7Xh8j3A5Augk42jngRCoKF"),
             ),

--- a/src/ingester/parser/tx_event_parser.rs
+++ b/src/ingester/parser/tx_event_parser.rs
@@ -64,9 +64,20 @@ pub fn create_state_update_v1(
         .zip(transaction_event.output_leaf_indices.iter())
     {
         let tree = transaction_event.pubkey_array[out_account.merkle_tree_index as usize];
-        let tree_and_queue = TreeInfo::get(&tree.to_string())
-            .ok_or(IngesterError::ParserError(format!("Missing queue for tree: {}", tree.to_string())))?
-            .clone();
+        let tree_and_queue = match TreeInfo::get(&tree.to_string()) {
+            Some(info) => info.clone(),
+            None => {
+                if super::SKIP_UNKNOWN_TREES {
+                    log::warn!("Skipping unknown tree: {}", tree.to_string());
+                    continue;
+                } else {
+                    return Err(IngesterError::ParserError(format!(
+                        "Missing queue for tree: {}",
+                        tree.to_string()
+                    )));
+                }
+            }
+        };
 
         let mut seq = None;
         if tree_and_queue.tree_type == TreeType::StateV1 {

--- a/src/ingester/parser/tx_event_parser.rs
+++ b/src/ingester/parser/tx_event_parser.rs
@@ -65,7 +65,7 @@ pub fn create_state_update_v1(
     {
         let tree = transaction_event.pubkey_array[out_account.merkle_tree_index as usize];
         let tree_and_queue = TreeInfo::get(&tree.to_string())
-            .ok_or(IngesterError::ParserError("Missing queue".to_string()))?
+            .ok_or(IngesterError::ParserError(format!("Missing queue for tree: {}", tree.to_string())))?
             .clone();
 
         let mut seq = None;


### PR DESCRIPTION
Add option to skip unknown merkle trees instead of failing during transaction parsing.

- Add `SKIP_UNKNOWN_TREES` constant to control behavior when trees aren't found
- Log warnings and continue processing instead of throwing errors for unknown trees
