### PR TITLE
fix: remove nullified accounts from output queue and add spent condition check

### DIFF
--- a/src/api/method/get_batch_address_update_info.rs
+++ b/src/api/method/get_batch_address_update_info.rs
@@ -57,14 +57,13 @@ pub async fn get_batch_address_update_info(
     conn: &DatabaseConnection,
     request: GetBatchAddressUpdateInfoRequest,
 ) -> Result<GetBatchAddressUpdateInfoResponse, PhotonApiError> {
-
     if request.limit as usize > MAX_ADDRESSES {
         return Err(PhotonApiError::ValidationError(format!(
             "Too many addresses requested {}. Maximum allowed: {}",
             request.limit, MAX_ADDRESSES
         )));
     }
-    
+
     let limit = request.limit;
     let merkle_tree_pubkey = request.tree;
     let tree_info = TreeInfo::get(&merkle_tree_pubkey.to_string())

--- a/src/api/method/get_queue_elements.rs
+++ b/src/api/method/get_queue_elements.rs
@@ -91,7 +91,9 @@ pub async fn get_queue_elements(
             }
         }
         QueueType::OutputStateV2 => {
-            query_condition = query_condition.add(accounts::Column::InOutputQueue.eq(true));
+            query_condition = query_condition
+                .add(accounts::Column::InOutputQueue.eq(true))
+                .add(accounts::Column::NullifiedInTree.eq(false));
             if let Some(start_queue_index) = request.start_queue_index {
                 query_condition =
                     query_condition.add(accounts::Column::LeafIndex.gte(start_queue_index as i64));

--- a/src/ingester/persist/leaf_node_proof.rs
+++ b/src/ingester/persist/leaf_node_proof.rs
@@ -127,7 +127,7 @@ pub async fn get_multiple_compressed_leaf_proofs(
         };
 
         if let Ok(tree_pubkey) = SerializablePubkey::try_from(tree.clone()) {
-            log::debug!("Tree {} root seq: {:?}", tree_pubkey, root_seq);
+            log::trace!("Tree {} root seq: {:?}", tree_pubkey, root_seq);
         }
 
         tree_to_root_seq.insert(tree, root_seq);
@@ -245,7 +245,7 @@ pub async fn get_multiple_compressed_leaf_proofs_from_full_leaf_info(
                 "Root node not found in proof".to_string(),
             ))?;
 
-            log::debug!(
+            log::trace!(
                 "MerkleProofWithContext for tree {} leaf_index {} root_seq: {}",
                 leaf_node.tree,
                 leaf_node.leaf_index,

--- a/src/ingester/persist/persisted_batch_event/nullify.rs
+++ b/src/ingester/persist/persisted_batch_event/nullify.rs
@@ -135,12 +135,11 @@ pub async fn persist_batch_nullify_event(
 
     process_nullify_accounts(&accounts, batch_nullify_event, leaf_nodes)?;
 
-    // 2. Mark elements as nullified in tree and remove from output queue.
+    // 2. Mark elements as nullified in tree and clear nullifier queue index.
     // Since these accounts have been nullified and their nullifiers written to the tree,
-    // they should not be processed again by batch append from the output queue.
+    // they are no longer in the nullifier queue.
     let query = accounts::Entity::update_many()
         .col_expr(accounts::Column::NullifiedInTree, Expr::value(true))
-        .col_expr(accounts::Column::InOutputQueue, Expr::value(false))
         .col_expr(accounts::Column::NullifierQueueIndex, Expr::value(Value::Int(None)))
         .filter(
             accounts::Column::NullifierQueueIndex

--- a/src/ingester/persist/persisted_batch_event/nullify.rs
+++ b/src/ingester/persist/persisted_batch_event/nullify.rs
@@ -6,6 +6,7 @@ use crate::migration::Expr;
 use log::debug;
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DatabaseTransaction, EntityTrait, QueryFilter, QueryTrait,
+    Value,
 };
 
 use super::helpers::{
@@ -140,6 +141,7 @@ pub async fn persist_batch_nullify_event(
     let query = accounts::Entity::update_many()
         .col_expr(accounts::Column::NullifiedInTree, Expr::value(true))
         .col_expr(accounts::Column::InOutputQueue, Expr::value(false))
+        .col_expr(accounts::Column::NullifierQueueIndex, Expr::value(Value::Int(None)))
         .filter(
             accounts::Column::NullifierQueueIndex
                 .gte(queue_start)

--- a/src/ingester/persist/persisted_batch_event/nullify.rs
+++ b/src/ingester/persist/persisted_batch_event/nullify.rs
@@ -134,9 +134,12 @@ pub async fn persist_batch_nullify_event(
 
     process_nullify_accounts(&accounts, batch_nullify_event, leaf_nodes)?;
 
-    // 2. Mark elements as nullified in tree.
+    // 2. Mark elements as nullified in tree and remove from output queue.
+    // Since these accounts have been nullified and their nullifiers written to the tree,
+    // they should not be processed again by batch append from the output queue.
     let query = accounts::Entity::update_many()
         .col_expr(accounts::Column::NullifiedInTree, Expr::value(true))
+        .col_expr(accounts::Column::InOutputQueue, Expr::value(false))
         .filter(
             accounts::Column::NullifierQueueIndex
                 .gte(queue_start)


### PR DESCRIPTION
- Add spent=true condition when querying input state queue elements
- Remove accounts from output queue when marking as nullified in tree
