### PR TITLE
fix: use each tree's own root_history_capacity for proof root index

### DIFF
--- a/src/api/method/get_validity_proof/prover/prove.rs
+++ b/src/api/method/get_validity_proof/prover/prove.rs
@@ -18,6 +18,37 @@ use light_batched_merkle_tree::constants::{
 use reqwest::Client;
 use sea_orm::DatabaseConnection;
 
+/// Computes a proof's index into its tree's circular root-history buffer.
+///
+/// Each tree (V1/V2, state/address) has its OWN `root_history_capacity`, so the
+/// modulo MUST use the capacity of the tree the proof actually came from. Using
+/// a different tree's capacity yields a stale/wrong index that only happens to
+/// be correct while `root_seq` is smaller than both capacities (e.g. on quiet
+/// devnet trees that have not wrapped yet).
+fn root_index_mod_queue(
+    root_seq: u64,
+    tree_capacity: u64,
+    fallback_capacity: u64,
+) -> Result<u64, PhotonApiError> {
+    // Prefer the proof's own tree capacity. Only fall back to the request-level
+    // capacity when the per-tree value is unavailable (0), which preserves the
+    // prior behavior for that degenerate case rather than newly rejecting it.
+    // If neither is known we cannot place the root in the ring buffer, so error
+    // instead of computing `% 0` (which would panic).
+    let capacity = match (tree_capacity, fallback_capacity) {
+        (0, 0) => {
+            return Err(PhotonApiError::UnexpectedError(
+                "root_history_capacity is unknown for this tree (tree metadata not synced); \
+                 cannot compute root index"
+                    .to_string(),
+            ))
+        }
+        (0, fallback) => fallback,
+        (capacity, _) => capacity,
+    };
+    Ok(root_seq % capacity)
+}
+
 pub(crate) async fn generate_proof(
     conn: &DatabaseConnection,
     db_account_proofs: Vec<MerkleProofWithContext>,
@@ -142,19 +173,20 @@ pub(crate) async fn generate_proof(
     let compressed_proof = compress_proof(&proof)?;
     let mut account_details = Vec::with_capacity(db_account_proofs.len());
     for acc_proof in db_account_proofs.iter() {
-        log::debug!("Proof generation: tree {} leaf_index {} root_seq {} queue_size {} root_index_mod_queue {}",
-            acc_proof.merkle_tree, acc_proof.leaf_index, acc_proof.root_seq, queue_size, acc_proof.root_seq % queue_size);
-
         let tree_info = TreeInfo::get(conn, &acc_proof.merkle_tree.to_string())
             .await?
             .ok_or(PhotonApiError::UnexpectedError(format!(
                 "Failed to get TreeInfo for account tree '{}'",
                 acc_proof.merkle_tree
             )))?;
+        let root_index_mod_queue =
+            root_index_mod_queue(acc_proof.root_seq, tree_info.root_history_capacity, queue_size)?;
+        log::debug!("Proof generation: tree {} leaf_index {} root_seq {} tree_capacity {} root_index_mod_queue {}",
+            acc_proof.merkle_tree, acc_proof.leaf_index, acc_proof.root_seq, tree_info.root_history_capacity, root_index_mod_queue);
         account_details.push(AccountProofDetail {
             hash: acc_proof.hash.to_string(),
             root: acc_proof.root.to_string(),
-            root_index_mod_queue: acc_proof.root_seq % queue_size,
+            root_index_mod_queue,
             leaf_index: acc_proof.leaf_index,
             merkle_tree_id: acc_proof.merkle_tree.to_string(),
             tree_info,
@@ -169,10 +201,12 @@ pub(crate) async fn generate_proof(
                 "Failed to get TreeInfo for address tree '{}'",
                 addr_proof.merkleTree
             )))?;
+        let root_index_mod_queue =
+            root_index_mod_queue(addr_proof.rootSeq, tree_info.root_history_capacity, queue_size)?;
         address_details.push(AddressProofDetail {
             address: addr_proof.address.to_string(),
             root: addr_proof.root.to_string(),
-            root_index_mod_queue: addr_proof.rootSeq % queue_size,
+            root_index_mod_queue,
             path_index: addr_proof.lowElementLeafIndex,
             merkle_tree_id: addr_proof.merkleTree.to_string(),
             tree_info,


### PR DESCRIPTION
## Problem

`getValidityProof` (v1 and v2) fetches a **single** `root_history_capacity` from **one** tree — preferring the account/state tree (`db_account_proofs[0].merkle_tree` in `v1.rs:113` / `v2.rs:238`) — and passes it to `generate_proof`, which applies that one capacity as the modulo divisor for **both** loops:

```rust
let queue_size = root_history_capacity;
// account loop
root_index_mod_queue: acc_proof.root_seq % queue_size,
// address loop
root_index_mod_queue: addr_proof.rootSeq % queue_size,
```

Each tree has its own circular root-history buffer size, so a request that mixes an **input account hash + a new address** (the Combined circuit) computes the address's root index using the **state tree's** capacity instead of the **address tree's**.

The index is `root_seq % capacity`, so the wrong divisor is a no-op while `root_seq` is below both capacities (quiet trees / devnet) and only diverges once the busy tree wraps — which is why this passes on devnet but fails intermittently on mainnet.

## Confirmed on live mainnet

| Tree | Pubkey | Capacity | Seq | Wrapped |
|---|---|---|---|---|
| V2 state | `bmt1LryLZUMmF7ZtqESaw7wifBXLfXHQYoE4GAmrahU` | 60 | 655 | ×10 |
| V2 address | `amt2kaJA14v3urZbZvnc5v2np8jqvc4Z8zDep5wbtzx` | 120 | 784 | ×6 |

A combined request returns `784 % 60 = 4` instead of the correct `784 % 120 = 64` — a wrong index into the address tree's root history that the on-chain `address_merkle_tree_root_index` check then rejects. V1 trees share capacity 2400 (state == address), so V1 is unaffected; the bug requires V2 batched trees that have wrapped.

## Fix

Switch the modulo to each proof's own `tree_info.root_history_capacity` — which both loops **already fetch** via `TreeInfo::get`. A small helper guards against a `0` capacity so we never divide by zero, falling back to the request-level capacity only when the per-tree value is missing.

## Notes

- This bug is also present byte-for-byte in upstream `Lightprotocol/photon` `main`; worth a corresponding upstream report.
- No existing test exercises a combined (hashes + new_addresses) request, and all test trees use capacity 2400 with tiny seqs, so the suite cannot currently catch this. A regression test needs a combined request + differing capacities + a wrapped seq — happy to add as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)