### PR TITLE
fix: use per-tree root_history_capacity for validity proof root index

### DIFF
--- a/src/api/method/get_validity_proof/mod.rs
+++ b/src/api/method/get_validity_proof/mod.rs
@@ -2,6 +2,38 @@ mod prover;
 mod v1;
 mod v2;
 
+use crate::api::error::PhotonApiError;
+use crate::dao::generated::{prelude::*, tree_metadata};
+use sea_orm::{ColumnTrait, DatabaseTransaction, EntityTrait, QueryFilter};
+use std::collections::HashMap;
+
+/// Fetches `root_history_capacity` for each unique tree referenced by the given
+/// proofs. Each tree (V1/V2, state/address) has its own queue size, so proofs
+/// must use their own tree's modulus when computing the root index.
+pub(crate) async fn fetch_root_history_capacities(
+    tx: &DatabaseTransaction,
+    trees: Vec<Vec<u8>>,
+) -> Result<HashMap<Vec<u8>, u64>, PhotonApiError> {
+    let mut capacities: HashMap<Vec<u8>, u64> = HashMap::new();
+    for tree in trees {
+        if capacities.contains_key(&tree) {
+            continue;
+        }
+        let meta = TreeMetadata::find()
+            .filter(tree_metadata::Column::TreePubkey.eq(tree.clone()))
+            .one(tx)
+            .await?
+            .ok_or_else(|| {
+                PhotonApiError::ValidationError(format!(
+                    "Tree metadata not found for {}. Please ensure tree metadata sync has been run.",
+                    bs58::encode(&tree).into_string()
+                ))
+            })?;
+        capacities.insert(tree, meta.root_history_capacity as u64);
+    }
+    Ok(capacities)
+}
+
 pub use prover::CompressedProof;
 pub use v1::{
     get_validity_proof, CompressedProofWithContext, GetValidityProofRequest,

--- a/src/api/method/get_validity_proof/prover/prove.rs
+++ b/src/api/method/get_validity_proof/prover/prove.rs
@@ -17,12 +17,13 @@ use light_batched_merkle_tree::constants::{
 };
 use reqwest::Client;
 use sea_orm::DatabaseConnection;
+use std::collections::HashMap;
 
 pub(crate) async fn generate_proof(
     conn: &DatabaseConnection,
     db_account_proofs: Vec<MerkleProofWithContext>,
     db_new_address_proofs: Vec<MerkleContextWithNewAddressProof>,
-    root_history_capacity: u64,
+    root_history_capacities: &HashMap<Vec<u8>, u64>,
     prover_url: &str,
     prover_api_key: Option<&str>,
 ) -> Result<ProverResult, PhotonApiError> {
@@ -81,15 +82,10 @@ pub(crate) async fn generate_proof(
         None
     };
 
-    // Always use the actual root_history_capacity from the database
-    // Each tree (V1 or V2) has its own queue size stored as root_history_capacity
-    let queue_size = root_history_capacity;
-
     log::debug!(
-        "Queue size: state_tree_height={}, address_tree_height={}, queue_size={}",
+        "Generating proof: state_tree_height={}, address_tree_height={}",
         state_tree_height,
         address_tree_height,
-        queue_size
     );
 
     let batch_inputs = HexBatchInputsForProver {
@@ -142,9 +138,20 @@ pub(crate) async fn generate_proof(
     let compressed_proof = compress_proof(&proof)?;
     let mut account_details = Vec::with_capacity(db_account_proofs.len());
     for acc_proof in db_account_proofs.iter() {
-        log::debug!("Proof generation: tree {} leaf_index {} root_seq {} queue_size {} root_index_mod_queue {}",
-            acc_proof.merkle_tree, acc_proof.leaf_index, acc_proof.root_seq, queue_size, acc_proof.root_seq % queue_size);
-
+        let tree_key = acc_proof.merkle_tree.to_bytes_vec();
+        let capacity = root_history_capacities
+            .get(&tree_key)
+            .copied()
+            .ok_or_else(|| {
+                PhotonApiError::UnexpectedError(format!(
+                    "No root_history_capacity found for account tree '{}'",
+                    acc_proof.merkle_tree
+                ))
+            })?;
+        log::debug!(
+            "Proof generation: tree {} leaf_index {} root_seq {} capacity {} root_index_mod_queue {}",
+            acc_proof.merkle_tree, acc_proof.leaf_index, acc_proof.root_seq, capacity, acc_proof.root_seq % capacity
+        );
         let tree_info = TreeInfo::get(conn, &acc_proof.merkle_tree.to_string())
             .await?
             .ok_or(PhotonApiError::UnexpectedError(format!(
@@ -154,7 +161,7 @@ pub(crate) async fn generate_proof(
         account_details.push(AccountProofDetail {
             hash: acc_proof.hash.to_string(),
             root: acc_proof.root.to_string(),
-            root_index_mod_queue: acc_proof.root_seq % queue_size,
+            root_index_mod_queue: acc_proof.root_seq % capacity,
             leaf_index: acc_proof.leaf_index,
             merkle_tree_id: acc_proof.merkle_tree.to_string(),
             tree_info,
@@ -163,6 +170,16 @@ pub(crate) async fn generate_proof(
 
     let mut address_details = Vec::with_capacity(db_new_address_proofs.len());
     for addr_proof in db_new_address_proofs.iter() {
+        let tree_key = addr_proof.merkleTree.to_bytes_vec();
+        let capacity = root_history_capacities
+            .get(&tree_key)
+            .copied()
+            .ok_or_else(|| {
+                PhotonApiError::UnexpectedError(format!(
+                    "No root_history_capacity found for address tree '{}'",
+                    addr_proof.merkleTree
+                ))
+            })?;
         let tree_info = TreeInfo::get(conn, &addr_proof.merkleTree.to_string())
             .await?
             .ok_or(PhotonApiError::UnexpectedError(format!(
@@ -172,7 +189,7 @@ pub(crate) async fn generate_proof(
         address_details.push(AddressProofDetail {
             address: addr_proof.address.to_string(),
             root: addr_proof.root.to_string(),
-            root_index_mod_queue: addr_proof.rootSeq % queue_size,
+            root_index_mod_queue: addr_proof.rootSeq % capacity,
             path_index: addr_proof.lowElementLeafIndex,
             merkle_tree_id: addr_proof.merkleTree.to_string(),
             tree_info,

--- a/src/api/method/get_validity_proof/v1.rs
+++ b/src/api/method/get_validity_proof/v1.rs
@@ -5,14 +5,13 @@ use crate::api::method::get_validity_proof::prover::prove::generate_proof;
 use crate::api::method::get_validity_proof::CompressedProof;
 use crate::common::typedefs::context::Context;
 use crate::common::typedefs::hash::Hash;
-use crate::dao::generated::{prelude::*, tree_metadata};
 use crate::ingester::persist::get_multiple_compressed_leaf_proofs;
 use crate::{
     api::error::PhotonApiError, common::typedefs::serializable_pubkey::SerializablePubkey,
 };
 use jsonrpsee_core::Serialize;
 use light_sdk_types::constants::ADDRESS_TREE_V1;
-use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, TransactionTrait};
+use sea_orm::{DatabaseConnection, TransactionTrait};
 use serde::Deserialize;
 use utoipa::ToSchema;
 
@@ -109,32 +108,13 @@ pub async fn get_validity_proof(
         Vec::new()
     };
 
-    // Fetch tree metadata for root_history_capacity
-    let tree_pubkey = if !db_account_proofs.is_empty() {
-        db_account_proofs[0].merkle_tree
-    } else if !db_new_address_proofs.is_empty() {
-        db_new_address_proofs[0].merkleTree
-    } else {
-        // This should not happen as we check for empty proofs later
-        return Err(PhotonApiError::ValidationError(
-            "No proofs available to determine tree".to_string(),
-        ));
-    };
-
-    let tree_bytes = tree_pubkey.to_bytes_vec();
-    let tree_metadata_result = TreeMetadata::find()
-        .filter(tree_metadata::Column::TreePubkey.eq(tree_bytes))
-        .one(&tx)
-        .await?;
-
-    let root_history_capacity = tree_metadata_result
-        .map(|m| m.root_history_capacity as u64)
-        .ok_or_else(|| {
-            PhotonApiError::ValidationError(format!(
-                "Tree metadata not found for {}. Please ensure tree metadata sync has been run.",
-                tree_pubkey
-            ))
-        })?;
+    // Fetch root_history_capacity per tree so each proof uses its own tree's modulus.
+    let trees: Vec<Vec<u8>> = db_account_proofs
+        .iter()
+        .map(|p| p.merkle_tree.to_bytes_vec())
+        .chain(db_new_address_proofs.iter().map(|p| p.merkleTree.to_bytes_vec()))
+        .collect();
+    let root_history_capacities = super::fetch_root_history_capacities(&tx, trees).await?;
 
     tx.commit().await?;
 
@@ -149,7 +129,7 @@ pub async fn get_validity_proof(
         conn,
         db_account_proofs,
         db_new_address_proofs,
-        root_history_capacity,
+        &root_history_capacities,
         prover_url,
         prover_api_key,
     )

--- a/src/api/method/get_validity_proof/v2.rs
+++ b/src/api/method/get_validity_proof/v2.rs
@@ -6,7 +6,7 @@ use crate::api::method::get_validity_proof::v1::GetValidityProofRequest;
 use crate::api::method::get_validity_proof::CompressedProof;
 use crate::common::typedefs::context::Context;
 use crate::common::typedefs::hash::Hash;
-use crate::dao::generated::{accounts, prelude::*, tree_metadata};
+use crate::dao::generated::accounts;
 use crate::ingester::persist::get_multiple_compressed_leaf_proofs;
 use crate::{
     api::error::PhotonApiError, common::typedefs::serializable_pubkey::SerializablePubkey,
@@ -233,41 +233,17 @@ pub async fn get_validity_proof_v2(
         Vec::new()
     };
 
-    // Fetch tree metadata for root_history_capacity
-    // First try to get tree from accounts needing full proofs, then from prove-by-index accounts
-    let tree_pubkey = if !db_account_proofs_for_prover.is_empty() {
-        Some(db_account_proofs_for_prover[0].merkle_tree)
-    } else if !db_new_address_proofs_for_prover.is_empty() {
-        Some(db_new_address_proofs_for_prover[0].merkleTree)
-    } else if !request.new_addresses_with_trees.is_empty() {
-        Some(request.new_addresses_with_trees[0].tree)
-    } else {
-        // Try to get tree from prove-by-index accounts
-        accounts_for_prove_by_index_inputs
-            .iter()
-            .find_map(|opt_acc| opt_acc.as_ref().map(|acc| acc.merkle_context.tree))
-    };
-
-    let root_history_capacity = if let Some(tree_pubkey) = tree_pubkey {
-        let tree_bytes = tree_pubkey.to_bytes_vec();
-        let tree_metadata_result = TreeMetadata::find()
-            .filter(tree_metadata::Column::TreePubkey.eq(tree_bytes))
-            .one(&tx)
-            .await?;
-
-        tree_metadata_result
-            .map(|m| m.root_history_capacity as u64)
-            .ok_or_else(|| {
-                PhotonApiError::ValidationError(format!(
-                    "Tree metadata not found for {}. Please ensure tree metadata sync has been run.",
-                    tree_pubkey
-                ))
-            })?
-    } else {
-        return Err(PhotonApiError::ValidationError(
-            "Cannot determine tree for fetching metadata".to_string(),
-        ));
-    };
+    // Fetch root_history_capacity per tree so each proof uses its own tree's modulus.
+    let trees: Vec<Vec<u8>> = db_account_proofs_for_prover
+        .iter()
+        .map(|p| p.merkle_tree.to_bytes_vec())
+        .chain(
+            db_new_address_proofs_for_prover
+                .iter()
+                .map(|p| p.merkleTree.to_bytes_vec()),
+        )
+        .collect();
+    let root_history_capacities = super::fetch_root_history_capacities(&tx, trees).await?;
 
     tx.commit().await?;
 
@@ -280,7 +256,7 @@ pub async fn get_validity_proof_v2(
             conn,
             db_account_proofs_for_prover,
             db_new_address_proofs_for_prover,
-            root_history_capacity,
+            &root_history_capacities,
             prover_url,
             prover_api_key,
         )


### PR DESCRIPTION
## Problem

When a `getValidityProof` / `getValidityProofV2` request combines input accounts with new addresses, the root index for **every** proof was computed using a single `root_history_capacity` taken from the first tree (the state tree).

V2 state trees and V2 address trees have different root history lengths:

| Tree | `root_history_capacity` |
|------|------------------------|
| V2 state   | 200 (`DEFAULT_BATCH_ROOT_HISTORY_LEN`) |
| V2 address | 120 (`DEFAULT_ADDRESS_BATCH_ROOT_HISTORY_LEN`) |

So address proofs were reduced modulo the wrong queue size (`rootSeq % 200` instead of `rootSeq % 120`), producing an incorrect root index — often `0` when `rootSeq` is a multiple of the state capacity. When the moduli diverge, proofs intermittently fail on-chain root validation.

## Fix

- Fetch `root_history_capacity` **per tree** and reduce each proof's `rootSeq` by its own tree's capacity.
- Extract the per-tree lookup into a shared `fetch_root_history_capacities` helper used by both v1 and v2.
- `generate_proof` now takes `&HashMap<Vec<u8>, u64>` (tree pubkey -> capacity) instead of a single `u64`, and looks up each account/address proof's tree.

## Notes

- Removes the previous `db_account_proofs[0]` / `[0]` direct slice indexing in favor of iterators.
- In v2, the old code computed a capacity even for prove-by-index-only requests that never call the prover (and could spuriously error); the new code only looks up capacities for trees actually sent to the prover.

## Testing

- `cargo clippy` clean on changed files (no new warnings).